### PR TITLE
[Testing] Add full CI tasks for debug-router

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,82 @@ on:
       - main
 
 jobs:
+  static-check:
+    runs-on: lynx-ubuntu-22.04-avd-medium
+    steps:
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ${{ github.workspace }}
+      - name: Install Common Dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |-
+            set -e
+            python3 -m pip install PyYAML -i https://pypi.org/simple
+            python3 -m pip install requests
+            tools/hab sync .
+      - name: Run file type check
+        run: |
+          source tools/envsetup.sh
+          python3 tools_shared/git_lynx.py check --checkers file-type
+      - name: Run java-lint check
+        run: |
+          source tools/envsetup.sh
+          python3 tools_shared/git_lynx.py check --checkers java-lint
+      - name: Run android-check-style check
+        run: |
+          source tools/envsetup.sh
+          python3 tools_shared/git_lynx.py check --checkers android-check-style
+      - name: Run commit-message check
+        run: |
+          source tools/envsetup.sh
+          python3 tools_shared/git_lynx.py check --checkers commit-message
+      - name: Run coding-style check
+        run: |
+          source tools/envsetup.sh
+          cd tools_shared
+          ./hab sync -f .
+          source envsetup.sh
+          cd ..
+          git lynx check --checkers coding-style
+      - name: Run cpplint check
+        run: |
+          source tools/envsetup.sh
+          python3 tools_shared/git_lynx.py check --checkers cpplint
+
+  unittest-build-check:
+    runs-on: lynx-ubuntu-22.04-avd-large
+    steps:
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - name: Install Common Dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |-
+            python3 -m pip install PyYAML -i https://pypi.org/simple
+            tools/hab sync .
+      - name: Run Unittests
+        run: |
+          set -e
+          source tools/envsetup.sh
+          python3 test/unit_test/check_test_build.py
+          python3 test/unit_test/check_test_run.py
+
   android-example-build:
     runs-on: lynx-ubuntu-22.04-avd-large
     steps:
@@ -17,7 +93,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -28,11 +104,85 @@ jobs:
         run: cd $GITHUB_WORKSPACE/test/e2e_test/AndroidExample &&  chmod +x ./gradlew
       - name: Build the AAR
         run: |-
-            mkdir tools/android_tools
-            source tools/envsetup.sh
-            pushd test/e2e_test/AndroidExample
-            ./gradlew :DebugRouter:assemblerelease
-            popd
+          source tools/envsetup.sh
+          pushd test/e2e_test/AndroidExample
+          ./gradlew :DebugRouter:assemblerelease
+          popd
+
+  android-websocket-connection-ci-check:
+    runs-on: lynx-ubuntu-22.04-physical-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 7.33.6
+      - name: Grant execute permission for gradlew
+        run: cd $GITHUB_WORKSPACE/test/e2e_test/AndroidExample &&  chmod +x ./gradlew
+      - name: Run the android websocket connection check
+        run: |-
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
+          tools/hab sync . -f
+          source tools/envsetup.sh
+          python3 test/connect_test/check_android_connection_ci.py -t websocket
+
+  android-usb-connection-ci-check:
+    runs-on: lynx-ubuntu-22.04-physical-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 7.33.6
+      - name: Grant execute permission for gradlew
+        run: cd $GITHUB_WORKSPACE/test/e2e_test/AndroidExample &&  chmod +x ./gradlew
+      - name: Run the android usb connection check
+        run: |-
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
+          tools/hab sync . -f
+          source tools/envsetup.sh
+          python3 test/connect_test/check_android_connection_ci.py -t usb
+
+  android-unittest-check:
+    runs-on: lynx-ubuntu-22.04-physical-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 7.33.6
+      - name: Grant execute permission for gradlew
+        run: cd $GITHUB_WORKSPACE/test/e2e_test/AndroidExample &&  chmod +x ./gradlew
+      - name: Run the android unittests check
+        run: |-
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
+          tools/hab sync . -f
+          source tools/envsetup.sh
+          python3 test/unit_test/check_android_unittest.py
 
   ios-debugrouter-lib-build:
     runs-on: lynx-darwin-14-medium
@@ -56,6 +206,37 @@ jobs:
           bundle exec pod install --verbose --repo-update
           xcodebuild clean -workspace DebugRouter.xcworkspace -scheme DebugRouter -configuration Debug
           xcodebuild -workspace DebugRouter.xcworkspace -scheme DebugRouter -configuration Debug -arch arm64 -derivedDataPath iOSCoreBuild/DerivedData -sdk iphonesimulator
+          popd
+
+  ios-unittest-check:
+    runs-on: lynx-darwin-14-medium
+    env:
+      POD_VERSION: 5.0.5
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 7.33.6
+      - name: Run the ios unittests check
+        run: |-
+          tools/hab sync . -f
+          source tools/envsetup.sh
+          set -e
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          pushd test/e2e_test/iOSExample
+          root_dir=$(pwd) && SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install
+          bundle exec pod install --verbose --repo-update
+          xcodebuild clean -workspace DebugRouter.xcworkspace -scheme DebugRouter -configuration Debug
+          xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
+          sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
+          echo $sdkVersion > sdk.txt
+          xcodebuild build-for-testing ARCHS=arm64 -workspace DebugRouter.xcworkspace -scheme DebugRouter_Tests -enableCodeCoverage YES -configuration Debug -sdk iphonesimulator$(cat sdk.txt) COMPILER_INDEX_STORE_ENABLE=NO -derivedDataPath iOSCoreBuild/DerivedData -dest"platform=iOS Simulator,OS=$(cat sdk.txt),name=iPhone 11" SYMROOT=`pwd`/Build/Products
+          chmod u+x xctestrunner
+          ./xctestrunner --xctestrun `pwd`/Build/Products/DebugRouter_Tests_iphonesimulator$(cat sdk.txt)-arm64.xctestrun --work_dir `pwd` --output_dir `pwd`/iOSCoreBuild/DerivedData simulator_test
           popd
 
   debug-router-connector-npm-package-build:

--- a/.tools_shared
+++ b/.tools_shared
@@ -1,0 +1,18 @@
+checker-config:
+  file-type-checker:
+    binary-files-allow-list:
+      - 'test/e2e_test/iOSExample/Assets.xcassets/AppIcon.appiconset/*'
+      - 'test/e2e_test/AndroidExample/app/src/main/res/*'
+      - 'test/e2e_test/AndroidExample/gradle/wrapper/gradle-wrapper.jar'
+      - 'test/e2e_test/iOSExample/Provisions/LynxDevToolsDebugRouterDis.mobileprovision'
+
+  coding-style-checker:
+    ignore-suffixes:
+      - '_jni.h'
+      - 'pnpm-lock.yaml'
+      - 'Podfile.yml'
+      - '.d.ts'
+      - '.r.ts'
+    ignore-dirs:
+      - '^third_party/*'
+      - '^build/*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,69 @@ When you’re ready to make a code change, please create a pull request:
 1. Fork the repository and clone it to your local machine.
 2. Create a new branch: `git checkout -b name-of-your-branch`.
 3. Make your changes.
-4. Once you have finished the necessary tests and verifications locally, commit the changes with a commit message.
+4. Once you have finished the necessary tests and verifications locally, commit the changes with a commit message in the following format (some parts are optional):
+   ```
+   [Label] Title of the commit message (one line)
+
+   Summary of change:
+   Longer description of change addressing as appropriate: why the change
+   is made, context if it is part of many changes, description of previous
+   behavior and newly introduced differences, etc.
+
+   Long lines should be wrapped to 72 columns for easier log message
+   viewing in terminals.
+
+   issue: #xxx
+   doc: https://xxxxxxxx
+   TEST: Test cases
+   ```
+   Some parts in the message template are required, while others are optional.
+   We use the labels `[Required]` and `[Optional]` to differentiate them in the detailed explanation below:
+    - **[Required]** The first line of the commit message should be the title, summarizing the changes (the title must
+      be on a separate line).
+    - **[Required]** The title must start with at least one label, and the first label must be one of the following:
+      `Feature`, `BugFix`, `Refactor`, `Optimize`, `Infra`, `Testing`, `Doc`. The format should be: `[Label]`, e.g.,
+      `[BugFix]`, `[Feature]`, `[BugFix][Tools]` (there must be at least one space between the label(s) and the title
+      content, and the title must not be empty).
+      >
+      > Which label should I use? Here are the explanations for them:
+      > - **`[Feature]`**: New features, new functions, or changes to existing features and functions. For example:
+      >   - `[Feature] Add new API for data binding` Add a new API for data binding
+      >   - `[Feature] Add service for light sensors` Add a service for light sensors
+      >   - `[Feature][Log] Support async event report` Support asynchronous event reporting
+      > - **`[BugFix]`**: Fixes for functional defects, performance anomalies, and problems in developer tools, etc.
+      For example:
+      >   - `[BugFix] Fix exception when playing audio` Fix the exception when playing audio
+      >   - `[BugFix] Fix leaks in xxx` Fix the memory leak problem in xxx
+      >   - `[BugFix][DevTool] Fix data error in DevTool` Fix the data error in the debug tool
+      > - **`[Refactor]`**: The overall refactoring of a module or function (mainly refers to large-scale code rewriting
+      or architecture optimization; small-scale refactoring can be classified as Optimize). For example:
+      >   - `[Refactor][Memory] Memory management in xxxx` Refactor the memory management of the xxx module
+      >   - `[Refactor][TestBench] XX module in TestBench` Refactor the xxx module in the TestBench
+      > - **`[Optimize]`**: Small-scale optimization of a certain feature or indicator,
+      such as performance optimization, memory optimization, etc. For example:
+      >   - `[Optimize][Performance] Jank when scrolling in xxxx` Optimization of the smoothness when scrolling in xxxx
+      > - **`[Infra]`**: Changes related to the compilation framework, CQ configuration, basic tools, etc. For example:
+      >   - `[Infra][Compile] Use -Oz compile params in xxx` Use -Oz compilation parameters
+      > - **`[Testing]`**: Modifications related to test cases and test frameworks. For example:
+      >   - `[Testing][Android] Fix xxx test case for Android` Fix a test case for Android
+      >   - `[Testing] Optimize test process` Optimize the process of a certain test framework
+      >
+      >
+      > Modifications only involving test cases, even if it is a `BugFix`, should be classified as `Testing`.
+      If both `Feature` code and related test cases are submitted in the same patch,
+      it should be classified as `Feature`.
+    - **[Required]** The section following the title should be the summary, providing a detailed description of the
+      changes (there must be a blank line between the title and the summary).
+    - **[Optional]** The commit can be linked to an issue, and the issue ID needs to appear in the format
+      `issue: #xxx`.
+    - **[Optional]** The commit can be linked to a document. If you labeled your changes as `Feature` or `Refactor`,
+      this is required. The format of a doc link should be like this: `doc: https://xxxxxxx`
+    - **[Optional]** The commit can be linked to tests (unit tests, UI tests). You can write the case names in the
+      format: `TEST: test_case_1, test_case_2`
+      <br>
+      We have set up a CI workflow to ensure that the commit message meets our formatting requirements.
+      So please make sure your message is well formatted before starting the Pull Request process.
 5. Push the changes to your remote branch and start a pull request.
 > We encourage the submission of small patches and only accept PRs that contain a single commit. Therefore, please split your PR into separate ones if it contains multiple commits, or squash them into a single commit if there are not too many changes.
 > The CI will reject any PR that contains more than one commit.
@@ -39,9 +101,39 @@ A pull request needs to be verified by the CI jobs and reviewed by the Lynx auth
 
 Once you submit a pull request, you can invite the contributors of the repository to review your changes. If you have no idea whom to invite to review your changes, the Github branch protection rules and `git blame` are the right places to start.
 
-While any contributor can review your changes, at least one of the authors from [default reviewers](./DEFAULT_REVIEWERS) should be on the reviewer list. Default reviewers can help trigger the CI workflow run to verify the changes (if this is your first PR for DebugRouter, you'll see a pending approval on the PR discussion area after you submit the PR) and then start the landing process. (The reason why the workflow run needs to be triggered by default reviewers is that they need to make sure the new changes will not introduce any risks)
+While any contributor can review your changes, at least one of the authors from [default reviewers](./DEFAULT_REVIEWERS) should be on the reviewer list. Default reviewers can help trigger the CI workflow run to verify the changes (if this is your first PR for DebugRouter, you'll see a pending approval on the PR discussion area after you submit the PR) and then start the landing process. 
+
+> The workflow run needs to be triggered by default reviewers so they can ensure the new changes will not introduce any risks.
 
 Typically, a pull request will be reviewed **within one week**. The landing process will be triggered manually if the changes pass all CI checks and are ready to be merged.
+
+### Static Code Analysis Tasks
+CI tasks include static code analysis, unit testing, building, etc. You can run static code analysis tasks:
+```
+source tools/envsetup.sh
+tools/hab sync . -f
+source tools_shared/envsetup.sh 
+git lynx check
+```
+
+The table below shows the specific tasks performed by `git lynx check`:
+
+|Task Name|Description|
+|----|----|
+|`coding-style`|Check the coding style of files|
+|`commit-message`|Check the format of commit message|
+|`cpplint`|Check your C++ code for style violations and potential errors|
+|`java-lint`|Check your Java code for style violations and potential errors|
+|`android-check-style`|Check the import style of Android code|
+|`file-type`|Check whether there are any binary files (We do not recommend storing binary files in the repository)|
+
+The specific programming languages and tools supported by `coding-style` task:
+
+|Language|Supported|Formatting Tool|
+|----|----|----|
+|C,C++,Objective-C,Java|✅|clang-format|
+|TypeScript|✅|prettier|
+|GN|✅|gn|
 
 ## 🖊 Code Style
 

--- a/DEPS
+++ b/DEPS
@@ -41,6 +41,13 @@ deps = {
         "ignore_in_git": True,
         "condition": system in ['linux', 'darwin', 'windows']
     },
+    'build/linux/debian_sid_amd64-sysroot': {
+        "type": "http",
+        "url": "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/79a7783607a69b6f439add567eb6fcb48877085c/debian_sid_amd64_sysroot.tar.xz",
+        "ignore_in_git": True,
+        "condition": machine == "x86_64" and system == "linux",
+        "require": ["build"]
+    },
     'buildtools/cmake': {
         "type": "http",
         "url": {
@@ -53,20 +60,52 @@ deps = {
     'buildtools/node': {
         "type": "http",
         "url": {
-            "linux-x86_64": "https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-x64.tar.gz",
-            "linux-arm64": "https://nodejs.org/dist/v16.18.1/node-v16.18.1-linux-arm64.tar.gz",
-            "darwin-x86_64": "https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-x64.tar.gz",
-            "darwin-arm64": "https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-arm64.tar.gz",
-            "windows-x86_64": "https://nodejs.org/dist/v16.18.1/node-v16.18.1-win-x64.zip"
+            "linux-x86_64": "https://nodejs.org/dist/v18.19.1/node-v18.19.1-linux-x64.tar.gz",
+            "linux-arm64": "https://nodejs.org/dist/v18.19.1/node-v18.19.1-linux-arm64.tar.gz",
+            "darwin-x86_64": "https://nodejs.org/dist/v18.19.1/node-v18.19.1-darwin-x64.tar.gz",
+            "darwin-arm64": "https://nodejs.org/dist/v18.19.1/node-v18.19.1-darwin-arm64.tar.gz",
+            "windows-x86_64": "https://nodejs.org/dist/v18.19.1/node-v18.19.1-win-x64.zip"
         }.get(f'{system}-{machine}', None),
         "sha256": {
-            "linux-x86_64": "8949919fc52543efae3bfd057261927c616978614926682ad642915f98fe1981",
-            "linux-arm64": "d6caa1439e8f3fbf4855b5cc1d09ae3eee31fc54ec29b7170603222ba6f8dfe6",
-            "darwin-x86_64": "c190e106d4ac6177d1db3a5a739d39dd68bd276ba17f3d3c84039a93717e081e",
-            "darwin-arm64": "71720bb0a80cf158d8fdf492def08048befd953ad45e2458b1d095e32c612ba7",
-            "windows-x86_64": "db6a81de8e8ca3444495f1bcf04a883c076b4325d0fbaa032a190f88b38b30c5"
+            "linux-x86_64": "724802c45237477dbe5777923743e6c77906830cae03a82b5653ebd75b301dda",
+            "linux-arm64": "2913e8544d95c8be9e6034c539ec0584014532166a088bf742629756c3ec42e2",
+            "darwin-x86_64": "ab67c52c0d215d6890197c951e1bd479b6140ab630212b96867395e21d813016",
+            "darwin-arm64": "0c7249318868877032ed21cc0ed450015ee44b31b9b281955521cd3fc39fbfa3",
+            "windows-x86_64": "ff08f8fe253fba9274992d7052e9d9a70141342d7b36ddbd6e84cbe823e312c6"
         }.get(f'{system}-{machine}', None),
         "ignore_in_git": True,
         "condition": system in ['linux', 'darwin', 'windows']
+    },
+    'third_party/libcxx': {
+        "type": "git",
+        "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx",
+        "commit": "64d36e572d3f9719c5d75011a718f33f11126851",
+        "ignore_in_git": True,     
+    },
+    'third_party/libcxxabi': {
+        "type": "git",
+        "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi",
+        "commit": "9572e56a12c88c011d504a707ca94952be4664f9",
+        "ignore_in_git": True,
+    },
+    'test/e2e_test/iOSExample/xctestrunner': {
+        "type": "http",
+        "url": "https://github.com/google/xctestrunner/releases/download/0.2.15/ios_test_runner.par",
+        "decompress": False,
+        "condition": system in ['darwin'],
+    },
+    "tools_shared": {
+        "type": "solution",
+        "url": "https://github.com/lynx-family/tools-shared.git",
+        "commit": "271dba582cab4409de488da3fa6e6761fb2a1cdd",
+        'deps_file': 'dependencies/DEPS',
+        "ignore_in_git": True,
+    },
+    'third_party/gyp': {
+        "type": "git",
+        "url": "https://chromium.googlesource.com/external/gyp",
+        "commit": "9d09418933ea2f75cc416e5ce38d15f62acd5c9a",
+        "ignore_in_git": True,
+        "condition": system in ['linux', 'darwin', 'windows'],
     },
 }

--- a/test/connect_test/check_android_connection_ci.py
+++ b/test/connect_test/check_android_connection_ci.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script build DebugRouter and run it's UnitTests.
+return 0 iff android demo can be built.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import requests
+import xml.etree.ElementTree as ET
+import json
+
+debugrouter_root_dir=sys.path[0] + "/../.."
+
+def CheckExecute(command):
+  status = subprocess.check_call(command, shell=True)
+  if status != 0:
+    print(("%s failed" %(command)) + status)
+    sys.exit(1)
+def CheckExecuteDoNotWait(command):
+  subprocess.Popen(command, shell=True)
+
+
+def AndroidBuildSetup():
+  print('\nStarting checking if DebugRouter can be built.')
+  print('debugrouter_root_dir:' + debugrouter_root_dir)
+  os.chdir(debugrouter_root_dir)
+  cur_work_dir = os.getcwd() + "/test/e2e_test/AndroidExample"
+  os.chdir(cur_work_dir)
+  print('cur_work_dir:' + os.getcwd())
+
+  android_ndk = os.environ.get('ANDROID_NDK')
+  android_sdk = os.environ.get('ANDROID_HOME')
+
+  local_pth = """
+  ## This file must *NOT* be checked into Version Control Systems,
+  # as it contains information specific to your local configuration.
+  #
+  # Location of the SDK. This is only used by Gradle.
+  # For customization when using a Version Control System, please read the
+  # header note.
+  #Wed Aug 21 19:06:01 CST 2019
+  ndk.dir=%s
+  sdk.dir=%s
+
+  """ % (android_ndk, android_sdk)
+
+  f = open('local.properties', 'w+')
+  f.write(local_pth)
+  f.close()
+
+
+def StartRunEmuAndInstallTestApk(args):
+  command = "%s/tools/android_tools/emu_bootup.sh --verbose" %(debugrouter_root_dir)
+  print("start emu:")
+  CheckExecute(command)
+
+  debug_router_android_apk_file = './app/build/outputs/apk/debug/app-debug.apk'
+  print("install test apk:" + debug_router_android_apk_file)
+  CheckExecute("adb install -r %s" % (debug_router_android_apk_file))
+  return 0
+
+def TestAndroidCon(args):
+  print("start TestAndroidWebSocketCon:")
+  os.chdir(debugrouter_root_dir + "/debug_router_connector")
+  print('cur_work_dir:' + os.getcwd())
+  command_build_driver = "../buildtools/node/bin/npm install && ../buildtools/node/bin/npm run build"
+  CheckExecute(command_build_driver)
+  os.chdir(debugrouter_root_dir + "/test/e2e_test/connector_test")
+  # start test
+  command_run = ""
+  print('cur_work_dir:' + os.getcwd())
+  if (args.conection_type == "websocket"):
+    print('start: websocket')
+    command_run = "../../../buildtools/node/bin/npm install && ../../../buildtools/node/bin/node websocket.js"
+  else:
+    if(args.conection_type == "usb"):
+      print('start: usb')
+      command_run = "../../../buildtools/node/bin/npm install && ../../../buildtools/node/bin/node usb.js"
+  CheckExecute(command_run)
+
+def CheckBuildDebugRouterTestApk(args):
+  command = './gradlew clean'
+  CheckExecute(command)
+
+  print('Build androidTest!')
+  command = './gradlew :app:assembleDebug'
+  CheckExecute(command) # app location: ./app/build/outputs/apk/debug/app-debug.apk
+
+def CheckTestResult(log_file):
+  if not os.path.exists(log_file):
+    print("run_test.log not find!!!")
+    sys.exit(1)
+  with open(log_file, 'r') as f:
+    content = f.read()
+    if 'FAILURES!!!' in content:
+      sys.exit(1)
+
+
+def CheckAndroidConnectionCI(args):
+  AndroidBuildSetup()
+  CheckBuildDebugRouterTestApk(args)
+  if(args.build):
+    sys.exit(0)
+  StartRunEmuAndInstallTestApk(args)
+  CheckExecute("adb logcat -c")
+  CheckExecuteDoNotWait("adb logcat")
+  TestAndroidCon(args)
+
+def main(args):
+  CheckAndroidConnectionCI(args)
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+    description='assign the devices locations to run tests')
+  parser.add_argument('-t', '--conection_type', required=True)
+  parser.add_argument('-b', '--build', action='store_true')
+  parser.add_argument('-d', '--devices', dest='devices', default="localhost",
+                      help='assign the local device to run tests')
+  args = parser.parse_args()
+  sys.exit(main(args))

--- a/test/unit_test/check_android_unittest.py
+++ b/test/unit_test/check_android_unittest.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script build DebugRouter and run it's UnitTests.
+return 0 iff android demo can be built.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import requests
+import xml.etree.ElementTree as ET
+import json
+
+debugrouter_root_dir=sys.path[0] + "/../.."
+
+def CheckExecute(command):
+  status = subprocess.check_call(command, shell=True)
+  if status != 0:
+    print(("%s failed" %(command)) + status)
+    sys.exit(1)
+def CheckExecuteDoNotWait(command):
+  subprocess.Popen(command, shell=True)
+
+
+def AndroidBuildSetup():
+  print('Starting checking if DebugRouter can be built.')
+  print('debugrouter_root_dir:' + debugrouter_root_dir)
+  os.chdir(debugrouter_root_dir)
+  cur_work_dir = os.getcwd() + "/test/e2e_test/AndroidExample"
+  os.chdir(cur_work_dir)
+  print('cur_work_dir:' + os.getcwd())
+
+
+  android_ndk = os.environ.get('ANDROID_NDK')
+  android_sdk = os.environ.get('ANDROID_HOME')
+
+  local_pth = """
+  ## This file must *NOT* be checked into Version Control Systems,
+  # as it contains information specific to your local configuration.
+  #
+  # Location of the SDK. This is only used by Gradle.
+  # For customization when using a Version Control System, please read the
+  # header note.
+  #Wed Aug 21 19:06:01 CST 2019
+  ndk.dir=%s
+  sdk.dir=%s
+
+  """ % (android_ndk, android_sdk)
+
+  f = open('local.properties', 'w+')
+  f.write(local_pth)
+  f.close()
+
+
+def CheckUnitTestInstallAndRun(args):
+  command = "%s/tools/android_tools/emu_bootup.sh --verbose" %(debugrouter_root_dir)
+  print("start emu:")
+  CheckExecute(command)
+
+  debug_router_android_apk_file = '../../../debug_router/Android/DebugRouter/build/outputs/apk/androidTest/debug/DebugRouter-debug-androidTest.apk'
+  print("install test apk:" + debug_router_android_apk_file)
+  CheckExecute("adb install -r %s" % (debug_router_android_apk_file))
+
+  CheckExecute("adb logcat -c")
+  CheckExecuteDoNotWait("adb logcat")
+
+  print("add permission for test.apk")
+  CheckExecute('adb shell pm grant com.lynx.debugrouter.test android.permission.WRITE_EXTERNAL_STORAGE')
+
+  print("check permission:")
+  CheckExecute('adb shell dumpsys package com.lynx.debugrouter.test | grep android.permission.WRITE_EXTERNAL_STORAGE')
+
+  print("check dir:")
+  CheckExecute('adb shell ls /sdcard')
+
+  print("\n======================================================= start test:")
+  # TODO -e coverage true -e coverageFile /sdcard/coverage_debug_router.ec
+  debug_router_command = """
+    adb shell am instrument -w  -e debug false \
+        com.lynx.debugrouter.test/androidx.test.runner.AndroidJUnitRunner | tee run_test.log
+  """
+  CheckExecute(debug_router_command)
+  CheckTestResult('run_test.log')
+  return 0
+
+def CheckUnitTestBuild(args):
+  print(("run test on %s"%(args.devices)))
+  command = './gradlew clean'
+  CheckExecute(command)
+
+  print('Build androidTest!')
+  command = './gradlew :Debugrouter:assembleDebugAndroidTest'\
+    ' --parallel --configure-on-demand'\
+    ' -x lint'\
+    ' -Penable_coverage=true'
+  CheckExecute(command)
+
+def CheckTestResult(log_file):
+  if not os.path.exists(log_file):
+    print("run_test.log not find!!!")
+    sys.exit(1)
+  with open(log_file, 'r') as f:
+    content = f.read()
+    if 'FAILURES!!!' in content:
+      sys.exit(1)
+
+
+def CheckAndroidUnitTests(args):
+  AndroidBuildSetup()
+  CheckUnitTestBuild(args)
+  CheckUnitTestInstallAndRun(args)
+
+def main(args):
+  CheckAndroidUnitTests(args)
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+    description='assign the devices locations to run tests')
+  parser.add_argument('-d', '--devices', dest='devices', default="localhost",
+                      help='assign the local device to run tests')
+  args = parser.parse_args()
+  sys.exit(main(args))

--- a/test/unit_test/check_test_build.py
+++ b/test/unit_test/check_test_build.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright 2020 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script build unittests for debug-router.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from collections import namedtuple
+
+OS_PLATFORM=''
+
+if sys.platform == 'darwin':
+  OS_PLATFORM = 'mac'
+elif sys.platform.startswith('linux'):
+  OS_PLATFORM = 'linux64'
+else:
+  print('Erorr, host OS not supported!')
+  sys.exit(1)
+
+def CheckUnitTestsBuild():
+  print('Starting checking if unittests can be built.')
+
+  gn_common_build_args = """
+    enable_unittests = true
+  """
+
+  gn_gen_cmd = "buildtools/gn/gn gen out/Default --args=\"" + gn_common_build_args + "\""
+  gn_clean_cmd = 'buildtools/gn/gn clean out/Default'
+  build_base_tests_cmd = 'buildtools/ninja/ninja -C out/Default example_unittest'
+
+  subprocess.check_call(gn_gen_cmd, shell=True)
+  subprocess.check_call(gn_clean_cmd, shell=True)
+  subprocess.check_call(build_base_tests_cmd, shell=True)
+
+  print('Congratulations! Unittests can be built.\n')
+  sys.exit(0)
+
+def main():
+  CheckUnitTestsBuild()
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/test/unit_test/check_test_run.py
+++ b/test/unit_test/check_test_run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright 2020 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script checks unit test results
+"""
+
+import os
+import subprocess
+import sys
+
+def CheckUnitTestRun():
+  print('Check unittest cases...')
+  cwd = os.getcwd()
+  os.environ['LYNX_ROOT_DIR'] = cwd
+
+  print('Check base test cases...')
+  run_basetest_command = 'python3 test/unit_test/run_unittests.py -c -a -t example_unittest'
+  subprocess.check_call(run_basetest_command, shell=True)
+  print('Congratulations! All base unittests are passed.\n')
+
+def main():
+  CheckUnitTestRun()
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/test/unit_test/lynx_env.py
+++ b/test/unit_test/lynx_env.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# Copyright 2020 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+def GetSourceRoot():
+  """
+  Get the Lynx source root directory.
+
+  Returns:
+    Absolute Lynx source root directory.
+  """
+  if 'LYNX_ROOT_DIR' in os.environ.keys():
+    return os.environ['LYNX_ROOT_DIR']
+  else:
+    print('LYNX_ROOT_DIR not set, please run "source tools/envsetup.sh".')
+    sys.exit(1)
+
+
+def GetBuildRoot(output_directory):
+  """
+  Get the build root directory (GN build).
+
+  Args:
+    Configured gn out out directory, eg: 'out/Default'
+  Returns:
+    The absolute directory of build root, eg: '$LYNX_ROOT_DIR/out/Default'
+  """
+  source_root = GetSourceRoot()
+  build_root = os.path.join(source_root, output_directory)
+  if os.path.exists(build_root):
+    return build_root
+  else:
+    print('Build root directory: ' + build_root + ' does not exits.')
+    sys.exit(1)
+
+def GetTestDirectoryOnDevice(timestamp):
+  """
+  Get the test root directory on device.
+
+  Args:
+    The unique timestamp of a test run.
+  Returns:
+    The absolute directory of the test run.
+  """
+  return os.path.join('/data/local/tmp', 'test-' + timestamp)
+
+def main():
+  print(GetSourceRoot())
+  print(GetBuildRoot("out/Default"))
+  print(GetTestDirectoryOnDevice())
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/test/unit_test/run_unittests.py
+++ b/test/unit_test/run_unittests.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright 2020 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import lynx_env
+import optparse
+import os
+import re
+import subprocess
+import sys
+
+from datetime import datetime
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+BUILD_ROOT = 'out/Default' # The default build root is 'out/Default'
+# The default timestamp of test, every test run has an unique timestamp.
+TEST_TIMESTAMP = '0000'
+TEST_CASES_DIR = 'test_cases'
+
+
+def GetTestRootPathOnAndroidDevice():
+  return lynx_env.GetTestDirectoryOnDevice(TEST_TIMESTAMP)
+
+
+def GetTestBinaryPathOnAndroidDevice(test):
+  return os.path.join(GetTestRootPathOnAndroidDevice(), test)
+
+
+def GetTestFilterString(gtest_filter):
+  return '--gtest_filter=%s' % (gtest_filter)
+
+def GenerateGeneralTestOptionsString(opts):
+  result = GetTestFilterString(opts.gtest_filter)
+  if opts.gtest_also_run_disabled_tests:
+    result = result + ' ' + '--gtest_also_run_disabled_tests'
+  return result;
+
+def PushFileToDevice(file_on_local, file_on_device):
+  adb_cmd = ['adb', 'push']
+  adb_cmd.append(file_on_local)
+  adb_cmd.append(file_on_device)
+  p = subprocess.Popen(' '.join(adb_cmd),
+                       stdout = subprocess.PIPE,
+                       stderr = subprocess.PIPE,
+                       shell=True)
+  output, error = p.communicate()
+  if p.returncode < 0:
+    print(('Error push files: ' + error))
+    sys.exit(0 - p.returncode)
+  print(output)
+
+
+def SetupTestEnviroment():
+  # Create the test root directory.
+  test_dir_on_device = GetTestRootPathOnAndroidDevice()
+  adb_cmd = ['adb', 'shell', 'mkdir', '-p', test_dir_on_device]
+  subprocess.check_call(' '.join(adb_cmd), shell=True)
+
+def SetupTestBinary(test):
+  # Push test binary to device.
+  file_on_output = os.path.join(lynx_env.GetBuildRoot(BUILD_ROOT),
+                                'exe.stripped',
+                                test)
+  file_on_device = os.path.join(GetTestRootPathOnAndroidDevice(), test)
+  PushFileToDevice(file_on_output, file_on_device)
+
+  # Setup permisson of test binary.
+  adb_cmd = ['adb', 'shell', 'chmod', 'u+x']
+  adb_cmd.append(file_on_device)
+  p = subprocess.Popen(' '.join(adb_cmd),
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE,
+                       shell=True)
+  output, error = p.communicate()
+  if p.returncode < 0:
+    print(("Setup test binary error: " + error))
+    sys.exit(0 - p.returncode)
+  print(output)
+
+
+def CleanupTestEnviroment():
+  test_dir_on_device = GetTestRootPathOnAndroidDevice()
+  adb_cmd = ['adb', 'shell', 'rm', '-r', test_dir_on_device]
+  # Remove all cases on device first.
+  p = subprocess.Popen(' '.join(adb_cmd),
+                       stdout = subprocess.PIPE,
+                       stderr = subprocess.PIPE,
+                       shell = True)
+  output, error = p.communicate()
+  if output: print(output)
+  if error: print(('Error:' + error))
+
+
+def CheckTestResult(test_result, return_code):
+  failed_cases_re = re.compile('(\d+)\s+FAILED TEST')
+  for line in test_result.split(b'\n'):
+    if failed_cases_re.search(line.decode('utf-8')):
+      return 1
+  return return_code
+
+
+def RunTestSuiteOnAndroidDevice(device, test, general_test_options):
+  adb_cmd = ['adb', 'shell']
+  gtest_command = GetTestBinaryPathOnAndroidDevice(test) + ' ' + general_test_options;
+  gtest_command = ' '.join(gtest_command)
+  adb_cmd.append('\"%s\"' % (gtest_command))
+  adb_cmd.append(GetTestRootPathOnAndroidDevice())
+  adb_cmd = ' '.join(adb_cmd)
+  print(('Run test with command: ' + adb_cmd))
+  p = subprocess.Popen([adb_cmd],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, shell=True)
+  result, error = p.communicate()
+  if p.returncode:
+    print(('Run test error: ' + result + error))
+  else:
+    print(('Run test sucess: ' + result))
+  return CheckTestResult(result, (-p.returncode))
+
+def TestOnAndroidDevice(opts):
+  # Start test.
+  global BUILD_ROOT
+  BUILD_ROOT = opts.output
+  global TEST_TIMESTAMP
+  TEST_TIMESTAMP= datetime.utcnow().strftime('%Y%m%d-%H%M%S-%f')
+
+  SetupTestEnviroment()
+
+  SetupTestBinary(opts.test)
+  return RunTestSuiteOnAndroidDevice(opts.device, opts.test, GenerateGeneralTestOptionsString(opts))
+
+def TestOnNativeEnv(opts):
+  BUILD_ROOT = opts.output
+  cmd = os.path.join(lynx_env.GetBuildRoot(BUILD_ROOT),
+                                opts.test)
+  cmd += ' ' + GenerateGeneralTestOptionsString(opts)
+  
+  # Use dump to write actual result to expected file.
+  if opts.dump == 'true':
+    cmd += ' ' + 'true'
+
+  print(cmd)
+  if opts.coverage:
+    os.environ['LLVM_PROFILE_FILE'] = os.path.join(BUILD_ROOT, '%s.profraw' % opts.test)
+  p = subprocess.Popen([cmd],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, shell=True)
+  if 'LLVM_PROFILE_FILE' in os.environ:
+    del os.environ['LLVM_PROFILE_FILE']
+  result, error = p.communicate()
+  encoding = 'utf-8'
+  if p.returncode:
+    print(('Run test error: ' + result.decode(encoding) + error.decode(encoding)))
+  else:
+    print(('Run test sucess: ' + result.decode(encoding)))
+  return CheckTestResult(result, (-p.returncode))
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('-d', '--device', default='',
+                    help='The target running device.')
+  parser.add_option('-a', '--gtest_also_run_disabled_tests', 
+                    action='store_true', help='Also run disabled tests')
+  parser.add_option('-t', '--test', help='Test binary to run.')
+  parser.add_option('-f', '--gtest-filter', default='*',
+                    help='The test filters passed to gtests,'
+                         'refer to "--gtest_filter" option of gtest.')
+  parser.add_option('-o', '--output', default='out/Default',
+                    help='The output directory, default is \'out/Default\'.')
+  parser.add_option('-l', '--layout-test', action='store_true',
+                    help='Run layout tests.')
+  parser.add_option('-u', '--dump', help='Dump result to expected files')
+  parser.add_option('-k', '--keep', action='store_true',
+                    help='Keep the test binaries and cases on devices')
+  parser.add_option('-p', '--platform', type = "choice", choices = ['', 'android'], default='',
+                    help='The platform to run unittest, will run on current platform by default.')
+  parser.add_option('-c', '--coverage', action='store_true',
+                    help='Get coverage data on the run')
+  opts, args = parser.parse_args()
+
+  print((opts.platform))
+  if (opts.platform == 'android'):
+    test_result = TestOnAndroidDevice(opts)
+  else:
+    test_result = TestOnNativeEnv(opts)
+  
+  if not opts.keep and opts.platform == 'android':
+    CleanupTestEnviroment()
+  return test_result
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/android_tools/android_env.sh
+++ b/tools/android_tools/android_env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ x"$1" = x"install" ];then
+  config_file=~/.bashrc
+  sed -i "/android-sdk config begin/,/android-sdk config end/ d" ${config_file}
+  echo '#-------------------  android-sdk config begin ----------------#' >> ${config_file}
+  echo 'export ANDROID_SDK_ROOT=${ANDROID_HOME}' >> ${config_file}
+  echo 'export PATH=${ANDROID_SDK_ROOT}/platform-tools:$PATH' >> ${config_file}
+  echo 'export PATH=${ANDROID_SDK_ROOT}/emulator:$PATH' >> ${config_file}
+  echo 'export PATH=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:$PATH' >> ${config_file}
+  echo 'export PATH=${ANDROID_SDK_ROOT}/tools/bin:$PATH' >> ${config_file}
+  echo '# export ANDROID_AVD_HOME=~/.android/avd' >> ${config_file}
+  echo '#-------------------  android-sdk config end ------------------#' >> ${config_file}
+fi
+
+# please set the ANDROID_HOME before hands
+export ANDROID_SDK_ROOT=${ANDROID_HOME}
+export PATH=${ANDROID_SDK_ROOT}/platform-tools:$PATH
+export PATH=${ANDROID_SDK_ROOT}/emulator:$PATH
+export PATH=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:$PATH
+export PATH=${ANDROID_SDK_ROOT}/tools/bin:$PATH
+# export ANDROID_AVD_HOME=~/.android/avd

--- a/tools/android_tools/emu_bootup.sh
+++ b/tools/android_tools/emu_bootup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2021 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+script_dir="$(cd "$(dirname "$0")"; pwd -P)"
+source ${script_dir}/android_env.sh
+
+avd_name=$1
+if [ x"${1}" == x"--verbose" ];then
+  set -x
+  avd_name=""
+fi
+devices_list=($(adb devices | grep "device$" | awk '{print $1}'))
+devices_nums=${#devices_list[@]}
+if [ ${devices_nums} -gt 0 ];then
+  # re-use the existed devices
+  adb devices
+  exit 0
+fi
+
+# if no active emulator exits, bootup the first avd in list
+if [ -z "${avd_name}" ];then
+  avd_list=($(emulator -list-avds))
+  avd_nums=${#avd_list[@]}
+  if [ ${avd_nums} -lt 1 ];then
+    echo "can not find emulator to bootup"
+    exit 1
+  fi
+  avd_name=${avd_list[0]}
+fi
+
+nohup emulator -no-window -writable-system -avd ${avd_name} &
+if [ $? -ne 0 ];then
+  echo "start emulator failed, please check nohup.out"
+fi
+
+# make sure server available
+adb start-server
+
+# wait devices to bootup
+retry=20
+devices_nums=0
+while [ $retry -gt 0 -a ${devices_nums} -lt 1 ]
+do
+  echo "wait device to bootup $retry"
+  retry=$(($retry-1))
+  sleep 5
+  devices_list=($(adb devices | grep "device$" | awk '{print $1}'))
+  devices_nums=${#devices_list[@]}
+done
+
+if [ ${devices_nums} -lt 1 ];then
+  echo "device bootup failed!"
+  exit -1
+fi
+# wait devices to boot_completed
+retry=20
+booted=0
+while [ $retry -gt 0 -a $booted -eq 0 ]
+do
+  echo "wait device to boot_completed $retry"
+  retry=$(($retry-1))
+  sleep 5
+  booted=$(adb shell getprop sys.boot_completed)
+  if [ -z "${booted}" ];then
+    booted=0
+  fi
+done
+
+adb devices


### PR DESCRIPTION
[Testing][Doc] Add full CI tasks for debug-router 
  1. Add full CI checks.
      a. simple cpp unittest check
      b. android and ios unittest check
      c. android websocket and usb cnnection check for debug-router-connector usgae.
  2. Improve the CONTRIBUTING.md due to the test completion.