### PR TITLE
[BugFix] Fix multiple thread problems in work_thread_executor.cc

### DIFF
--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -381,7 +381,6 @@ UsbClient::~UsbClient() {
   LOGI("UsbClient: ~UsbClient.");
   // TODO(popoaichuiniu) optimize thread policy of UsbClient's fields
   DisconnectInternal();
-  work_thread_.shutdown();
 }
 
 }  // namespace socket_server

--- a/debug_router/native/socket/work_thread_executor.cc
+++ b/debug_router/native/socket/work_thread_executor.cc
@@ -18,26 +18,38 @@ void WorkThreadExecutor::submit(std::function<void()> task) {
     return;
   }
   std::lock_guard<std::mutex> lock(task_mtx);
+  if (is_shut_down) {
+    return;
+  }
   tasks.push(task);
   cond.notify_one();
 }
 
 void WorkThreadExecutor::shutdown() {
-  std::lock_guard<std::mutex> lock(worker_mtx);
-  is_shut_down = true;
-  cond.notify_one();
-  if (worker) {
-    if (worker->joinable()) {
-      worker->join();
+  {
+    std::lock_guard<std::mutex> lock(task_mtx);
+    if (is_shut_down) {
+      return;
     }
-    worker.reset();
+    is_shut_down = true;
+    std::queue<std::function<void()>> empty;
+    tasks.swap(empty);
   }
+  cond.notify_all();
+
+  if (worker && worker->joinable()) {
+    worker->join();
+  }
+  worker.reset();
 }
 
 void WorkThreadExecutor::run() {
   while (!is_shut_down) {
     std::unique_lock<std::mutex> lock(task_mtx);
     cond.wait(lock, [this] { return !tasks.empty() || is_shut_down; });
+    if (is_shut_down) {
+      break;
+    }
     if (!tasks.empty()) {
       auto task = tasks.front();
       tasks.pop();

--- a/debug_router/native/socket/work_thread_executor.h
+++ b/debug_router/native/socket/work_thread_executor.h
@@ -29,7 +29,6 @@ class WorkThreadExecutor {
   std::unique_ptr<std::thread> worker;
   std::queue<std::function<void()>> tasks;
   std::mutex task_mtx;
-  std::mutex worker_mtx;
   std::condition_variable cond;
 };
 


### PR DESCRIPTION
    [BugFix] Fix multiple thread problems in work_thread_executor.cc

            1. Replace work_mutex with task_mutex in the shutdown method.
            2. Reduce the locking granularity of the task_mutex in the shutdown method.

    issue: #17