### PR TITLE
[BugFix]Fix crash that socket_guard_ maybe nullptr

### DIFF
--- a/debug_router/native/net/websocket_task.cc
+++ b/debug_router/native/net/websocket_task.cc
@@ -190,6 +190,10 @@ bool WebSocketTask::do_connect() {
     }
     CLOSESOCKET(sockfd);
   }
+  if (socket_guard_ == nullptr) {
+    LOGE("Connect " << url_.c_str() << "Error: socket_guard_ is nullptr.");
+    return false;
+  }
   freeaddrinfo(servinfo);
 
   char buf[512];


### PR DESCRIPTION
If the connect function has not succeeded, socket_guard_ may still be nullptr, and socket_guard_.Get() will cause the crash.