### PR TITLE
[BugFix]Fix that app crash for params is null when slot onMessage

### DIFF
--- a/debug_router/Android/DebugRouter/src/main/java/com/lynx/debugrouter/DebugRouterSlot.java
+++ b/debug_router/Android/DebugRouter/src/main/java/com/lynx/debugrouter/DebugRouterSlot.java
@@ -86,6 +86,9 @@ public class DebugRouterSlot {
   }
 
   public void onMessage(String type, String message) {
+    if (type == null || message == null) {
+      return;
+    }
     if (mDelegate != null) {
       mDelegate.onMessage(type, message);
     }


### PR DESCRIPTION
As above, add judgement for onMessage().