### PR TITLE
[Optimize]Add __cpp_exceptions judgement for no-exception

### DIFF
--- a/debug_router/native/socket/work_thread_executor.cc
+++ b/debug_router/native/socket/work_thread_executor.cc
@@ -40,16 +40,20 @@ void WorkThreadExecutor::shutdown() {
   cond.notify_all();
 
   if (worker && worker->joinable()) {
+#if __cpp_exceptions >= 199711L
     try {
+#endif
       if (worker->get_id() != std::this_thread::get_id()) {
         worker->join();
       } else {
         worker->detach();
       }
+#if __cpp_exceptions >= 199711L
     } catch (const std::exception& e) {
       LOGE("WorkThreadExecutor::shutdown worker->detach() failed, "
            << e.what());
     }
+#endif
   }
   worker.reset();
 }


### PR DESCRIPTION
Solve the problem that debug-router fails to compile when Lynx turns on no-exception.