### PR TITLE
[BugFix]  Fix thread safety issues when iterating over state_listeners_.

### DIFF
--- a/debug_router/native/core/debug_router_core.h
+++ b/debug_router/native/core/debug_router_core.h
@@ -115,6 +115,7 @@ class DebugRouterCore : public MessageTransceiverDelegate {
 
  protected:
   std::recursive_mutex slots_mutex_;
+  std::recursive_mutex state_listeners_mutex_;
   friend class MessageHandlerCore;
   std::unordered_map<int32_t, std::shared_ptr<core::NativeSlot> > slots_;
   std::string room_id_;


### PR DESCRIPTION
1. add judgement to avoid crash.
2. use another way to iterate over state_listeners_.
3. add state_listeners_mutex_ to lock the process to state_listeners.