### PR TITLE
[Optimize]Reduce unnecessary copies

### DIFF
--- a/debug_router/native/core/util.cc
+++ b/debug_router/native/core/util.cc
@@ -56,11 +56,11 @@ bool CheckHeaderFourthByte(const char *header, uint32_t payload_size_int) {
   return true;
 }
 
-std::string decodeURIComponent(std::string url) {
+std::string decodeURIComponent(const std::string &url) {
   int flag = 0;
   int code = 0;
   std::stringstream result_url_;
-  for (char c : url) {
+  for (const char &c : url) {
     if ((flag == 0) && (c == '%')) {
       flag = 1;
       continue;

--- a/debug_router/native/core/util.h
+++ b/debug_router/native/core/util.h
@@ -32,7 +32,7 @@ bool CheckHeaderFourthByte(const char *header, uint32_t payload_size_int);
 bool CheckHeaderThreeBytes(const char *header);
 
 // decode url
-std::string decodeURIComponent(std::string url);
+std::string decodeURIComponent(const std::string &url);
 
 }  // namespace util
 }  // namespace debugrouter


### PR DESCRIPTION
Optimize code by changing `std::string` to `const std::string&` for `url` to avoid unnecessary copies and improve performance.