### PR TITLE
[Optimize][android][ios][common] Provide the ability to register a custom WebSocket.

### DIFF
--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -139,7 +139,19 @@ DebugRouterCore::DebugRouterCore()
   thread::DebugRouterExecutor::GetInstance().Start();
 }
 
+void DebugRouterCore::SetCustomWebSocketTransceiver(
+    const std::shared_ptr<MessageTransceiver> &message_transceiver) {
+  std::lock_guard<std::mutex> lock_guard(custom_transceiver_mutex_);
+  custom_websocket_transceiver_ = message_transceiver;
+}
+
 void DebugRouterCore::Connect(const std::string &url, const std::string &room) {
+  {
+    std::lock_guard<std::mutex> lock_guard(custom_transceiver_mutex_);
+    if (custom_websocket_transceiver_) {
+      message_transceivers_[0] = custom_websocket_transceiver_;
+    }
+  }
   Connect(url, room, false);
 }
 

--- a/debug_router/native/core/debug_router_core.h
+++ b/debug_router/native/core/debug_router_core.h
@@ -85,6 +85,9 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   int AddGlobalHandler(DebugRouterGlobalHandler *handler);
   bool RemoveGlobalHandler(int handler_id);
 
+  void SetCustomWebSocketTransceiver(
+      const std::shared_ptr<MessageTransceiver> &message_transceiver);
+
   void AddMessageHandler(DebugRouterMessageHandler *handler);
   bool RemoveMessageHandler(const std::string &handler_name);
 
@@ -133,6 +136,7 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   void Reconnect();
   void Connect(const std::string &url, const std::string &room,
                bool is_reconnect);
+  std::shared_ptr<MessageTransceiver> custom_websocket_transceiver_;
   std::atomic<ConnectionState> connection_state_;
   std::shared_ptr<MessageTransceiver> current_transceiver_;
   std::vector<std::shared_ptr<MessageTransceiver> > message_transceivers_;
@@ -146,6 +150,7 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   std::string GetConnectionStateMsg(ConnectionState state);
   std::atomic<int32_t> usb_port_;
   std::atomic<int> handler_count_;
+  std::mutex custom_transceiver_mutex_;
 };
 
 }  // namespace core

--- a/debug_router/native/core/message_transceiver.cc
+++ b/debug_router/native/core/message_transceiver.cc
@@ -8,12 +8,6 @@ namespace debugrouter {
 namespace core {
 MessageTransceiver::MessageTransceiver() {}
 
-void MessageTransceiver::HandleReceivedMessage(const std::string &message) {
-  if (delegate_) {
-    delegate_->OnMessage(message, shared_from_this());
-  }
-}
-
 void MessageTransceiver::SetDelegate(MessageTransceiverDelegate *delegate) {
   delegate_ = delegate;
 }

--- a/debug_router/native/core/message_transceiver.h
+++ b/debug_router/native/core/message_transceiver.h
@@ -40,7 +40,6 @@ class MessageTransceiver
   virtual void Disconnect() = 0;
   virtual void Send(const std::string &data) = 0;
   virtual ConnectionType GetType() = 0;
-  virtual void HandleReceivedMessage(const std::string &message);
   virtual void SetDelegate(MessageTransceiverDelegate *delegate);
   virtual MessageTransceiverDelegate *delegate();
 

--- a/debug_router/native/net/socket_server_client.cc
+++ b/debug_router/native/net/socket_server_client.cc
@@ -85,9 +85,5 @@ void SocketServerClient::Send(const std::string &data) {
   socket_server_->Send(data);
 }
 
-void SocketServerClient::HandleReceivedMessage(const std::string &message) {
-  // empty
-}
-
 }  // namespace net
 }  // namespace debugrouter

--- a/debug_router/native/net/socket_server_client.h
+++ b/debug_router/native/net/socket_server_client.h
@@ -19,7 +19,6 @@ class SocketServerClient : public core::MessageTransceiver {
   void Disconnect() override;
   void Send(const std::string &data) override;
   core::ConnectionType GetType() override;
-  void HandleReceivedMessage(const std::string &message) override;
 
  private:
   std::shared_ptr<debugrouter::socket_server::SocketServer> socket_server_;


### PR DESCRIPTION
	1. add SetCustomWebSocketTransceiver interface on debug-router-core
	2. Remove the useless interface HandleReceivedMessage.

issue: #41