### PR TITLE
[BugFix][android][ios][common] Use work_thread_executor instead of raw thread

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -20,15 +20,20 @@ constexpr SocketType kInvalidSocket = INVALID_SOCKET;
 typedef int SocketType;
 constexpr SocketType kInvalidSocket = -1;
 #endif
+#include <mutex>
 
 namespace debugrouter {
 namespace base {
 
 class SocketGuard {
  public:
-  SocketType Get() const { return sock_; }
+  SocketType Get() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return sock_;
+  }
 
   void Reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
     if (sock_ != kInvalidSocket) {
       CLOSESOCKET(sock_);
     }
@@ -37,16 +42,14 @@ class SocketGuard {
 
   explicit SocketGuard(SocketType sock) : sock_(sock) {}
 
-  ~SocketGuard() {
-    if (sock_ != kInvalidSocket) {
-      CLOSESOCKET(sock_);
-    }
-  }
+  ~SocketGuard() { Reset(); }
+
   SocketGuard(const SocketGuard&) = delete;
   SocketGuard& operator=(const SocketGuard&) = delete;
 
  private:
   SocketType sock_;
+  std::mutex mutex_;
 };
 
 }  // namespace base


### PR DESCRIPTION
	Using WorkThreadExecutor can conveniently stop all threads of usb_client when it ends, avoiding unexpected resource access.

issue: #46