### PR TITLE
[BugFix][android][ios][common] Fix thread crash that occurs when calling worker.join() during WorkThreadExecutor shutdown.

### DIFF
--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -94,11 +94,14 @@ void SocketServerPosix::Start() {
     NotifyInit(GetErrorMessage(), "accept socket error");
     return;
   }
-  auto temp_usb_client = std::make_shared<UsbClient>(accept_socket_fd);
+  if (temp_usb_client_) {
+    temp_usb_client_->Stop();
+  }
+  temp_usb_client_ = std::make_shared<UsbClient>(accept_socket_fd);
   std::shared_ptr<ClientListener> listener =
       std::make_shared<ClientListener>(shared_from_this());
-  temp_usb_client->Init();
-  temp_usb_client->StartUp(listener);
+  temp_usb_client_->Init();
+  temp_usb_client_->StartUp(listener);
 }
 
 void SocketServerPosix::CloseSocket(int socket_fd) {

--- a/debug_router/native/socket/socket_server_api.cc
+++ b/debug_router/native/socket/socket_server_api.cc
@@ -69,6 +69,7 @@ void SocketServer::HandleOnCloseStatus(std::shared_ptr<UsbClient> client,
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
     if (!usb_client_ || usb_client_ != client) {
       LOGI("SocketServerApi OnMessage: client is null or not match.");
+      client->Stop();
       return;
     }
     usb_client_->Stop();
@@ -85,6 +86,7 @@ void SocketServer::HandleOnErrorStatus(std::shared_ptr<UsbClient> client,
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
     if (!usb_client_ || usb_client_ != client) {
       LOGI("SocketServerApi OnMessage: client is null or not match.");
+      client->Stop();
       return;
     }
     usb_client_->Stop();
@@ -127,6 +129,7 @@ void SocketServer::Close() {
 void SocketServer::Disconnect() {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
     if (!usb_client_) {
+      usb_client_->Stop();
       usb_client_ = nullptr;
     }
   });
@@ -135,6 +138,9 @@ void SocketServer::Disconnect() {
 SocketServer::~SocketServer() {
   if (!usb_client_) {
     usb_client_->Stop();
+  }
+  if (!temp_usb_client_) {
+    temp_usb_client_->Stop();
   }
   Close();
 }

--- a/debug_router/native/socket/socket_server_api.h
+++ b/debug_router/native/socket/socket_server_api.h
@@ -65,6 +65,7 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   std::unique_ptr<CountDownLatch> latch_;
   std::mutex queue_lock_;
   std::shared_ptr<UsbClient> usb_client_;
+  std::shared_ptr<UsbClient> temp_usb_client_;
 
   volatile SocketType socket_fd_ = kInvalidSocket;
 };


### PR DESCRIPTION
A UsbClient must call stop() before destruction to prevent threads from accessing its resources after it's destroyed.

issue: #42