### PR TITLE
[BugFix]Fix crash that occurs when transferring a huge message via USB.

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -22,6 +22,8 @@ constexpr SocketType kInvalidSocket = -1;
 #endif
 #include <mutex>
 
+#include "debug_router/native/log/logging.h"
+
 namespace debugrouter {
 namespace base {
 
@@ -42,7 +44,10 @@ class SocketGuard {
 
   explicit SocketGuard(SocketType sock) : sock_(sock) {}
 
-  ~SocketGuard() { Reset(); }
+  ~SocketGuard() {
+    LOGI("SocketGuard destruct.");
+    Reset();
+  }
 
   SocketGuard(const SocketGuard&) = delete;
   SocketGuard& operator=(const SocketGuard&) = delete;

--- a/debug_router/native/socket/usb_client.h
+++ b/debug_router/native/socket/usb_client.h
@@ -49,8 +49,8 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   void MessageDispatcher();
   void WriteMessage();
 
-  bool Read(SocketType socket_fd_, char *buffer, uint32_t read_size);
-  bool ReadAndCheckMessageHeader(char *header, SocketType socket_fd_);
+  bool Read(char *buffer, uint32_t read_size);
+  bool ReadAndCheckMessageHeader(char *header);
 
   void CloseClientSocket(SocketType socket_fd_);
   /**


### PR DESCRIPTION
1. add LOG for Usbclient stop.
2. add unique_ptr for payload to deal with huge message.