### PR TITLE
[Testing] Add USB e2e test for the crash that occurs when receiving large messages.

### DIFF
--- a/test/connect_test/check_android_connection_ci.py
+++ b/test/connect_test/check_android_connection_ci.py
@@ -77,12 +77,12 @@ def TestAndroidCon(args):
   command_run = ""
   print('cur_work_dir:' + os.getcwd())
   if (args.conection_type == "websocket"):
-    print('start: websocket')
+    print('start: websocket common test.')
     command_run = "../../../buildtools/node/bin/npm install && ../../../buildtools/node/bin/node websocket.js"
   else:
     if(args.conection_type == "usb"):
-      print('start: usb')
-      command_run = "../../../buildtools/node/bin/npm install && ../../../buildtools/node/bin/node usb.js"
+      print('start: usb common test and large message test.')
+      command_run = "../../../buildtools/node/bin/npm install && ../../../buildtools/node/bin/node usb.js && ../../../buildtools/node/bin/node large_message_test.js"
   CheckExecute(command_run)
 
 def CheckBuildDebugRouterTestApk(args):

--- a/test/e2e_test/connector_test/large_message_test.js
+++ b/test/e2e_test/connector_test/large_message_test.js
@@ -1,0 +1,41 @@
+const DebugRouterConnector = require("@lynx-js/debug-router-connector").DebugRouterConnector;
+ 
+const util = require('./util.js');
+
+async function main() {
+  const driver = new DebugRouterConnector({
+    manualConnect: true,
+    enableWebSocket: false,
+    enableAndroid: true,
+    enableIOS: true,
+    enableDesktop: false,
+    websocketOption: {}
+  });
+
+  const startActivity = 'adb shell am start -n com.lynx.debugrouter.testapp/com.lynx.debugrouter.testapp.MainActivity'
+  util.exec(startActivity, 10000).then((data) => {
+    console.log("startActivity:" + data);
+  }).catch((reason) => {
+    console.log("startActivity FAILED:" + reason);
+    process.exit(-1);
+  })
+
+  const devicesArray = await driver.connectDevices(6000);
+  console.log(devicesArray);
+
+  const clients = await driver.connectUsbClients(devicesArray[0].serial, 6000);
+  console.log(clients);
+
+  const client = clients[0];
+  console.log(client.info.query.raw_info);
+
+  // large message test, UsbClient::Read should not crash for large param size : 8388608
+  const largeMessageSize = 8388608;
+  const largeMessage = 'a'.repeat(largeMessageSize);
+  const result1 = await client.sendCustomizedMessage("App.GetCloseCoverageUploadSwitch", { message: largeMessage }, -1, "App");
+  console.log(result1);
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
use large message to test USBClient::Read.