### PR TITLE
[BugFix]Fix that snprintf may cause crash

### DIFF
--- a/debug_router/native/protocol/md5.cc
+++ b/debug_router/native/protocol/md5.cc
@@ -36,7 +36,9 @@ std::string MD5::hexdigest() const {
   if (!finalized) return "";
 
   char txbuf[33];
-  for (int i = 0; i < 16; i++) snprintf(txbuf + i * 2, 33, "%02x", digest[i]);
+  for (int i = 0; i < 16; i++) {
+    snprintf(txbuf + i * 2, 33 - i * 2, "%02x", digest[i]);
+  }
   txbuf[32] = 0;
   return std::string(txbuf);
 }


### PR DESCRIPTION
use 33 - i * 2 instead of 33 to execute snprintf.