### PR TITLE
[BugFix]Fix that port is polluted

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -35,6 +35,7 @@ class SocketGuard {
   }
 
   void Reset() {
+    LOGI("SocketGuard reset.");
     std::lock_guard<std::mutex> lock(mutex_);
     if (sock_ != kInvalidSocket) {
       CLOSESOCKET(sock_);

--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -75,14 +75,14 @@ int32_t SocketServerPosix::InitSocket() {
 }
 
 void SocketServerPosix::Start() {
-  int32_t port = kInvalidPort;
   if (socket_fd_ == kInvalidSocket) {
+    int32_t port = kInvalidPort;
     port = InitSocket();
     if (port == kInvalidPort) {
       return;
     }
+    NotifyInit(0, "port:" + std::to_string(port));
   }
-  NotifyInit(0, "port:" + std::to_string(port));
   LOGI("server socket:" << socket_fd_);
   struct sockaddr_in addr;
   socklen_t addrLen = sizeof(addr);
@@ -94,9 +94,12 @@ void SocketServerPosix::Start() {
     NotifyInit(GetErrorMessage(), "accept socket error");
     return;
   }
+  LOGI("accept usbclient socket:" << accept_socket_fd);
   if (temp_usb_client_) {
+    LOGI("close last connector, destroy temp_usb_client_.");
     temp_usb_client_->Stop();
   }
+  LOGI("create a new usb client.");
   temp_usb_client_ = std::make_shared<UsbClient>(accept_socket_fd);
   std::shared_ptr<ClientListener> listener =
       std::make_shared<ClientListener>(shared_from_this());

--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -55,6 +55,7 @@ void UsbClient::StartInternal(
     const std::shared_ptr<UsbClientListener> &listener) {
   LOGI("UsbClient: StartInternal.");
   connect_status_ = USBConnectStatus::CONNECTING;
+  LOGI("StartInternal, listener is:" << listener.get());
   listener_ = listener;
   StartReader();
   StartWriter();
@@ -211,6 +212,7 @@ void UsbClient::MessageDispatcher() {
 
     if (message.length() > 0) {
       if (listener_) {
+        LOGI("UsbClient: listener exists, do OnMessage.");
         listener_->OnMessage(shared_from_this(), message);
       }
     } else {


### PR DESCRIPTION
1. Fix the problem that the port value would be polluted if the Start() function was executed twice.
2. add some log.