### PR TITLE
[BugFix]Fix that current_transceiver_ maybe nullptr

### DIFF
--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -403,15 +403,23 @@ void DebugRouterCore::OnFailure(
       connection_state_.load(std::memory_order_relaxed) == DISCONNECTED) {
     return;
   }
-  if (current_transceiver_->GetType() == ConnectionType::kUsb) {
-    Json::Value catagaryJson;
-    catagaryJson["connect_type"] = "usb";
-    catagaryJson["error_msg"] = error_message;
-    std::string catagary = catagaryJson.toStyledString();
-    Report("OnFailure", catagary, "", "");
+  if (current_transceiver_ != nullptr) {
+    if (current_transceiver_->GetType() == ConnectionType::kUsb) {
+      Json::Value catagaryJson;
+      catagaryJson["connect_type"] = "usb";
+      catagaryJson["error_msg"] = error_message;
+      std::string catagary = catagaryJson.toStyledString();
+      Report("OnFailure", catagary, "", "");
+    } else {
+      Json::Value catagaryJson;
+      catagaryJson["connect_type"] = "websocket";
+      catagaryJson["error_msg"] = error_message;
+      std::string catagary = catagaryJson.toStyledString();
+      Report("OnFailure", catagary, "", "");
+    }
   } else {
     Json::Value catagaryJson;
-    catagaryJson["connect_type"] = "websocket";
+    catagaryJson["connect_type"] = "none";
     catagaryJson["error_msg"] = error_message;
     std::string catagary = catagaryJson.toStyledString();
     Report("OnFailure", catagary, "", "");


### PR DESCRIPTION
When the OnOpen function is not used to assign a value to current_transceiver_, nullptr will cause current_transceiver_->GetType() to crash.