### PR TITLE
[BugFix]Fix that OnFailure does not trigger the state_listener callback when USB is connected

### DIFF
--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -376,7 +376,9 @@ void DebugRouterCore::OnClosed(
   connection_state_.store(DISCONNECTED, std::memory_order_relaxed);
   current_transceiver_ = nullptr;
   NotifyConnectStateByMessage(DISCONNECTED);
-  if (retry_times_.load(std::memory_order_relaxed) >= 3) {
+  if (transceiver->GetType() == ConnectionType::kUsb ||
+      (transceiver->GetType() == ConnectionType::kWebSocket &&
+       retry_times_.load(std::memory_order_relaxed) >= 3)) {
     std::vector<std::shared_ptr<DebugRouterStateListener>> listeners;
     {
       std::lock_guard<std::recursive_mutex> lock(state_listeners_mutex_);
@@ -445,7 +447,10 @@ void DebugRouterCore::OnFailure(
   connection_state_.store(DISCONNECTED, std::memory_order_relaxed);
   current_transceiver_ = nullptr;
   NotifyConnectStateByMessage(DISCONNECTED);
-  if (retry_times_.load(std::memory_order_relaxed) >= 3) {
+
+  if (transceiver->GetType() == ConnectionType::kUsb ||
+      (transceiver->GetType() == ConnectionType::kWebSocket &&
+       retry_times_.load(std::memory_order_relaxed) >= 3)) {
     std::vector<std::shared_ptr<DebugRouterStateListener>> listeners;
     {
       std::lock_guard<std::recursive_mutex> lock(state_listeners_mutex_);


### PR DESCRIPTION

Add judgement to ensure that the listener callback can still be reached when USB is connected.