### PR TITLE
[Optimize] Only remove remote ports that Connector forward

### DIFF
--- a/debug_router_connector/src/device/Harmony/HarmonyDevice.ts
+++ b/debug_router_connector/src/device/Harmony/HarmonyDevice.ts
@@ -117,11 +117,17 @@ export default class HarmonyDevice extends BaseDevice {
     return new Promise<void>(async (resolve, reject) => {
       const forwards: Forward[] = await device.listForwards();
       for (let i = 0; i < forwards.length; i++) {
-        const result = await device.removeForward(
-          forwards[i].local,
-          forwards[i].remote,
-        );
-        defaultLogger.debug("removeForward result:" + result);
+        const local = forwards[i].local;
+        const remote = forwards[i].remote;
+        const remotePort = parseInt(remote.replace(/^tcp:/, ""), 10);
+        if (this.remotePorts.includes(remotePort)) {
+          const result = await device.removeForward(local, remote);
+          defaultLogger.debug("removeForward result:" + result);
+        } else {
+          defaultLogger.debug(
+            "not remove forward:" + local + ". for not used by connector",
+          );
+        }
       }
       resolve();
     });

--- a/debug_router_connector/src/device/android/AndroidDevice.ts
+++ b/debug_router_connector/src/device/android/AndroidDevice.ts
@@ -127,10 +127,19 @@ export default class AndroidDevice extends BaseDevice {
     return new Promise<void>(async (resolve, reject) => {
       const forwards: Forward[] = await device.listForwards();
       for (let i = 0; i < forwards.length; i++) {
-        const shellCmd = `adb -H ${this.adb.options.host} -P ${this.adb.options.port} forward --remove ${forwards[i].local}`;
-        defaultLogger.debug(shellCmd);
-        const result = await this.exeCmd(shellCmd);
-        defaultLogger.debug(result);
+        const local = forwards[i].local;
+        const remote = forwards[i].remote;
+        const remotePort = parseInt(remote.replace(/^tcp:/, ""), 10);
+        if (this.remotePorts.includes(remotePort)) {
+          const shellCmd = `adb -H ${this.adb.options.host} -P ${this.adb.options.port} forward --remove ${local}`;
+          defaultLogger.debug(shellCmd);
+          const result = await this.exeCmd(shellCmd);
+          defaultLogger.debug(result);
+        } else {
+          defaultLogger.debug(
+            "not remove forward:" + local + ". for not used by connector",
+          );
+        }
       }
       resolve();
     });

--- a/debug_router_connector/src/utils/hdc/command/host/listforward.ts
+++ b/debug_router_connector/src/utils/hdc/command/host/listforward.ts
@@ -10,6 +10,14 @@ export default class ListForwardCommand extends Command<Forward[]> {
   }
 
   private _parseResult(value: Buffer): Forward[] {
+    // fport ls value format (example):
+    // MJE0xxxxx    tcp:18501 tcp:8901    [Forward]
+    // what we want is:
+    // {
+    //   connectKey: "MJE0xxxxx",
+    //   local: "tcp:18501",
+    //   remote: "tcp:8901",
+    // }
     return value
       .toString("ascii")
       .split("\n")
@@ -18,17 +26,27 @@ export default class ListForwardCommand extends Command<Forward[]> {
         if (line.startsWith("[Fail]")) {
           throw new Error(line);
         }
-        const fLine = line.split("\t");
-        let taskInfo;
+        // split by space, and remove empty string
+        const parts = line.trim().split(/\s+/).filter(Boolean);
+        let taskInfo = "";
         let connectKey = "";
-        if (fLine.length > 2) {
-          taskInfo = fLine[1];
-          connectKey = fLine[0];
-        } else {
-          taskInfo = fLine[0];
+
+        if (
+          parts.length >= 3 &&
+          parts[1].includes(":") &&
+          parts[2].includes(":")
+        ) {
+          connectKey = parts[0];
+          taskInfo = `${parts[1]} ${parts[2]}`;
+        } else if (parts.length >= 2 && parts[1].includes(":")) {
+          connectKey = parts[0];
+          taskInfo = parts[1];
+        } else if (parts.length >= 1) {
+          taskInfo = parts[0];
         }
+
         taskInfo = taskInfo.replace("'", "");
-        let [local, remote] = taskInfo.split(" ");
+        const [local, remote = ""] = taskInfo.split(" ").filter(Boolean);
         return {
           connectKey,
           local,


### PR DESCRIPTION
1. Prevent the ports forwarded by other local plug-ins from being accidentally closed by the Connector.
2. Fix that return value got by `hdc fport ls` is not splited successfully, which cause hdc removeForward keep failure.