### PR TITLE
[BugFix] Resolve the issue where multiple Windows apps cannot connect to DebugRouterConnector

### DIFF
--- a/debug_router/native/socket/win/socket_server_win.cc
+++ b/debug_router/native/socket/win/socket_server_win.cc
@@ -38,15 +38,6 @@ int32_t SocketServerWin::InitSocket() {
     return kInvalidPort;
   }
 
-  bool on = true;
-  if (setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, (char *)&on,
-                 sizeof(on)) == -1) {
-    Close();
-    LOGE("setsockopt error:" << GetErrorMessage());
-    NotifyInit(GetErrorMessage(), "setsockopt error");
-    return kInvalidPort;
-  }
-
   bool flag = false;
   PORT_TYPE port = kStartPort;
   int bind_result = SOCKET_ERROR;


### PR DESCRIPTION
Remove the logic causing port reuse to fix the problem of multiple Windows apps being unable to connect to DebugRouterConnector simultaneously.