### PR TITLE
[Optimize]Enable trusted publishing for npm packages

### DIFF
--- a/.github/workflows/npm-manual-release.yml
+++ b/.github/workflows/npm-manual-release.yml
@@ -3,14 +3,16 @@ name: npm release
 on:
   push:
     tags:
-      - '*-connector'
+      - "*-connector"
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   npm-release-test:
     runs-on: macos-latest
+    environment: npm
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -20,6 +22,12 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.33.6
+
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Build debug-router-connector
         run: |-
@@ -36,7 +44,6 @@ jobs:
           npm install
           npm run build
           ls -al
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.REPO_DEBUG_ROUTER_NPM_TOKEN }}" > .npmrc
 
           if [[ $version == *"alpha"* ]]; then
               echo "Publishing alpha version..."
@@ -47,5 +54,3 @@ jobs:
           fi
 
           popd
-        env:
-          NPM_TOKEN: ${{ secrets.REPO_DEBUG_ROUTER_NPM_TOKEN }}

--- a/.github/workflows/remote-debug-driver-publish-npm.yml
+++ b/.github/workflows/remote-debug-driver-publish-npm.yml
@@ -3,14 +3,16 @@ name: remote-debug-driver npm release
 on:
   push:
     tags:
-      - '*-remote-debug-driver'
+      - "*-remote-debug-driver"
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   npm-release-test:
     runs-on: macos-latest
+    environment: npm
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -20,6 +22,12 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.33.6
+
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Build remote-debug-driver
         run: |-
@@ -36,8 +44,5 @@ jobs:
           npm install
           npm run build
           ls -al
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.REPO_REMOTE_DEBUG_DRIVER_NPM_TOKEN }}" > .npmrc
           npm publish --tag alpha
           popd
-        env:
-          NPM_TOKEN: ${{ secrets.REPO_REMOTE_DEBUG_DRIVER_NPM_TOKEN }}


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

See:

https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
https://docs.npmjs.com/trusted-publishers