### PR TITLE
[Feature]Add connection process tree tracing to debug_router_connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ tools/android_tools/
 **/oh-package-lock.json5
 **/.idea
 **/.cxx
-
+**/.jsonl

--- a/debug_router_connector/README.md
+++ b/debug_router_connector/README.md
@@ -32,11 +32,18 @@ const connector = new DebugRouterConnector({
   enableDesktop: true,
   enableNetworkDevice: true,
   networkDeviceOpt: {
-    ip: xx;
-    port:[port];
-  };
+    ip: xx,
+    port: [port],
+  },
+  connectionTrace: {
+    enabled: true,
+    output: "/tmp/debug-router-connection-trace.jsonl",
+  },
 });
 ```
+
+#### Connection trace (optional)
+Use `connectionTrace` to enable flat JSON-line connection logging, or set `DriverConnectionTracePath` to a file path. Each record includes a monotonically increasing `sequence`; socket-backed records also include `connectionAttemptId` for later trace analysis.
 
 #### Get Connected Clients
 You have two ways to get the connected clients.

--- a/debug_router_connector/src/connector/DebugRouterConnector.ts
+++ b/debug_router_connector/src/connector/DebugRouterConnector.ts
@@ -39,6 +39,12 @@ import {
   setClientTimeMap,
   setDeviceTimeMap,
 } from "./MonitorUtils";
+import { createConnectionTraceRecorder } from "../trace/ConnectionTraceRecorder";
+import type {
+  ConnectionTraceNode,
+  ConnectionTraceOptions,
+  ConnectionTraceRecorder,
+} from "../trace/ConnectionTraceRecorder";
 
 export type devOption = {
   manualConnect?: boolean;
@@ -69,6 +75,7 @@ export type devOption = {
     port: number[];
   };
   reportService?: DriverReportService | null;
+  connectionTrace?: ConnectionTraceOptions;
 };
 
 const DEFAULT_DEV_SERVE_PORT = 19783;
@@ -88,6 +95,7 @@ export class DebugRouterConnector {
   private enableDesktop: boolean;
   private readonly enableNetworkDevice: boolean;
   private readonly driverClient: DriverClient;
+  public readonly traceRecorder: ConnectionTraceRecorder | null = null;
   private readonly networkDeviceOpt:
     | {
         ip: string;
@@ -101,6 +109,8 @@ export class DebugRouterConnector {
   };
   private multiOpenCallback: MultiOpenCallback = new DefaultMultiOpenCallback();
   private monitoring: boolean = false;
+  private multiOpenMonitorTimer?: NodeJS.Timeout;
+  private closed: boolean = false;
   wssPort: number = DEFAULT_DEV_SERVE_PORT;
   wssHost: string | undefined;
   roomId: string | undefined;
@@ -159,6 +169,10 @@ export class DebugRouterConnector {
       this.usbConnectOpt.retryTime = 3000;
     }
     this.setOptionByEnv();
+    this.traceRecorder = createConnectionTraceRecorder(
+      option.connectionTrace,
+      process.env.DriverConnectionTracePath,
+    );
     this.devicesManager = new Set<DeviceManager>();
     this.driverClient = new DriverClient(this.createClientId());
     if (this.enableAndroid) {
@@ -216,7 +230,7 @@ export class DebugRouterConnector {
     }
     defaultLogger.info("startMonitorMultiOpen");
     this.monitorLatestDriverProcessFileSafely();
-    setInterval(() => {
+    this.multiOpenMonitorTimer = setInterval(() => {
       this.monitorLatestDriverProcessFileSafely();
     }, 500);
   }
@@ -446,10 +460,65 @@ export class DebugRouterConnector {
     this.events.off(event, callback);
   }
 
+  getConnectionTrace(limit?: number): ConnectionTraceNode[] {
+    return this.traceRecorder?.getRecentNodes(limit) ?? [];
+  }
+
+  onConnectionTrace(listener: (node: ConnectionTraceNode) => void): () => void {
+    if (!this.traceRecorder) {
+      return () => {};
+    }
+    return this.traceRecorder.addListener(listener);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    if (this.multiOpenMonitorTimer) {
+      clearInterval(this.multiOpenMonitorTimer);
+      this.multiOpenMonitorTimer = undefined;
+    }
+    this.disableAllClients();
+    if (this.wss) {
+      this.wss.close();
+      this.wss = null;
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+    await this.traceRecorder?.close();
+  }
+
   emit<Event extends keyof DebugerRouterDriverEvents>(
     event: Event,
     payload: DebugerRouterDriverEvents[Event],
   ): void {
+    if (event === "app-client-connected") {
+      this.traceRecorder?.recordAppClientConnected(payload as Client);
+    }
+    if (event === "app-client-disconnected") {
+      this.traceRecorder?.recordAppClientDisconnected(payload as number);
+    }
+    if (event === "websocket-app-client-connected") {
+      this.traceRecorder?.recordWebsocketAppClientConnected(
+        payload as WebSocketClient,
+      );
+    }
+    if (event === "websocket-app-client-disconnected") {
+      this.traceRecorder?.recordWebsocketAppClientDisconnected(
+        payload as number,
+      );
+    }
+    if (event === "websocket-web-client-connected") {
+      this.traceRecorder?.recordWebsocketWebClientConnected(
+        payload as WebSocketClient,
+      );
+    }
+    if (event === "websocket-web-client-disconnected") {
+      this.traceRecorder?.recordWebsocketWebClientDisconnected(
+        payload as number,
+      );
+    }
     this.events.emit(event, payload);
   }
 
@@ -463,6 +532,10 @@ export class DebugRouterConnector {
     defaultLogger.debug("register new device:" + device.serial);
     // register new device
     this.devices.set(device.info.serial, device);
+    this.traceRecorder?.recordDeviceRegistered(device.info.serial, {
+      os: device.info.os,
+      title: device.info.title,
+    });
     if (
       !this.manualConnect &&
       this.currentStatus === MultiOpenStatus.attached
@@ -482,6 +555,10 @@ export class DebugRouterConnector {
       return;
     }
     defaultLogger.debug("unregisterDevice:" + serial);
+    this.traceRecorder?.recordDeviceUnregistered(serial, {
+      os: device.info.os,
+      title: device.info.title,
+    });
     this.devices.delete(serial);
     device.disConnect(); // we'll only destroy upon replacement
     this.emit("device-disconnected", device);

--- a/debug_router_connector/src/device/BaseDevice.ts
+++ b/debug_router_connector/src/device/BaseDevice.ts
@@ -51,6 +51,10 @@ export abstract class BaseDevice {
 
   startWatchClient() {
     defaultLogger.debug("connectUsbClients: startWatchClient");
+    this.driver.traceRecorder?.recordWatchClientStart(this.info.serial, {
+      os: this.info.os,
+      title: this.info.title,
+    });
     this.clientController?.stopWatchClient();
     this.clientController = new ClientController(this.driver, this);
     this.clientController.startWatchClient();
@@ -58,6 +62,10 @@ export abstract class BaseDevice {
 
   async stopWatchClient() {
     defaultLogger.debug("connectUsbClients: stopWatchClient");
+    this.driver.traceRecorder?.recordWatchClientStop(this.info.serial, {
+      os: this.info.os,
+      title: this.info.title,
+    });
     if (this.clientController) {
       await this.clientController.stopWatchClient();
     }

--- a/debug_router_connector/src/device/Harmony/HarmonyDeviceManager.ts
+++ b/debug_router_connector/src/device/Harmony/HarmonyDeviceManager.ts
@@ -108,6 +108,13 @@ export default class HarmonyDeviceManager extends DeviceManager {
             this.retryCount = 0;
             defaultLogger.debug("tracker add:" + JSON.stringify(target));
             if (target.connStatus === "Connected") {
+              const serial = target.connectKey || target.connType;
+              if (!this.driver.devices.has(serial)) {
+                this.driver.traceRecorder?.recordDevicePlug(serial, {
+                  os: "Harmony",
+                  event: "add",
+                });
+              }
               this.registerDevice(this.hdcClient as Client, target);
             }
           });
@@ -122,9 +129,23 @@ export default class HarmonyDeviceManager extends DeviceManager {
               "tracker change to:" + JSON.stringify(newTarget),
             );
             if (newTarget.connStatus === "Connected") {
+              const serial = newTarget.connectKey;
+              if (!this.driver.devices.has(serial)) {
+                this.driver.traceRecorder?.recordDevicePlug(serial, {
+                  os: "Harmony",
+                  event: "change",
+                });
+              }
               this.registerDevice(this.hdcClient as Client, newTarget);
             } else {
               if (this.driver.devices.has(newTarget.connectKey)) {
+                this.driver.traceRecorder?.recordDeviceUnplug(
+                  newTarget.connectKey,
+                  {
+                    os: "Harmony",
+                    event: "change",
+                  },
+                );
                 this.driver.unregisterDevice(newTarget.connectKey);
               }
             }
@@ -134,8 +155,12 @@ export default class HarmonyDeviceManager extends DeviceManager {
             this.currentWatchStatus = WatchStatus.Watching;
             this.retryCount = 0;
             defaultLogger.debug("tracker remove:" + JSON.stringify(target));
-            if (this.driver.devices.has(target.connType)) {
-              this.driver.unregisterDevice(target.connType);
+            if (this.driver.devices.has(target.connectKey)) {
+              this.driver.traceRecorder?.recordDeviceUnplug(target.connectKey, {
+                os: "Harmony",
+                event: "remove",
+              });
+              this.driver.unregisterDevice(target.connectKey);
             }
           });
         })

--- a/debug_router_connector/src/device/android/AndroidDeviceManager.ts
+++ b/debug_router_connector/src/device/android/AndroidDeviceManager.ts
@@ -130,6 +130,13 @@ export class AndroidDeviceManager extends DeviceManager {
               serial: device.id,
             });
             if (device.type === "device") {
+              if (!this.driver.devices.has(device.id)) {
+                this.driver.traceRecorder?.recordDevicePlug(device.id, {
+                  os: "Android",
+                  event: "add",
+                  deviceType: device.type,
+                });
+              }
               this.registerDevice(this.adbClient as ADBClient, device);
             }
           });
@@ -143,9 +150,21 @@ export class AndroidDeviceManager extends DeviceManager {
               serial: device.id,
             });
             if (device.type === "device") {
+              if (!this.driver.devices.has(device.id)) {
+                this.driver.traceRecorder?.recordDevicePlug(device.id, {
+                  os: "Android",
+                  event: "change",
+                  deviceType: device.type,
+                });
+              }
               this.registerDevice(this.adbClient as ADBClient, device);
             } else {
               if (this.driver.devices.has(device.id)) {
+                this.driver.traceRecorder?.recordDeviceUnplug(device.id, {
+                  os: "Android",
+                  event: "change",
+                  deviceType: device.type,
+                });
                 this.driver.unregisterDevice(device.id);
               }
             }
@@ -160,6 +179,11 @@ export class AndroidDeviceManager extends DeviceManager {
               serial: device.id,
             });
             if (this.driver.devices.has(device.id)) {
+              this.driver.traceRecorder?.recordDeviceUnplug(device.id, {
+                os: "Android",
+                event: "remove",
+                deviceType: device.type,
+              });
               this.driver.unregisterDevice(device.id);
             }
           });

--- a/debug_router_connector/src/device/desktop/DesktopDeviceManager.ts
+++ b/debug_router_connector/src/device/desktop/DesktopDeviceManager.ts
@@ -23,6 +23,13 @@ export default class DesktopDeviceManager extends DeviceManager {
     } else {
       return;
     }
-    this.driver.registerDevice(device);
+    if (!this.driver.devices.has(device.serial)) {
+      this.driver.traceRecorder?.recordDevicePlug(device.serial, {
+        os: device.info.os,
+        event: "register",
+        synthetic: true,
+      });
+      this.driver.registerDevice(device);
+    }
   }
 }

--- a/debug_router_connector/src/device/ios/iOSDeviceManager.ts
+++ b/debug_router_connector/src/device/ios/iOSDeviceManager.ts
@@ -106,12 +106,22 @@ export default class IOSDeviceManager extends DeviceManager {
       usbmuxListener.on("attached", (udid: string) => {
         statusSocket.currentWatchStatus = WatchStatus.Watching;
         defaultLogger.debug("watchIOSDevices attached:" + JSON.stringify(udid));
+        if (!this.driver.devices.has(udid)) {
+          this.driver.traceRecorder?.recordDevicePlug(udid, {
+            os: "iOS",
+            event: "attached",
+          });
+        }
         this.handleDeviceConnect(udid, statusSocket);
       });
 
       usbmuxListener.on("detached", (udid: string) => {
         statusSocket.currentWatchStatus = WatchStatus.Watching;
         defaultLogger.debug("watchIOSDevices detached:" + JSON.stringify(udid));
+        this.driver.traceRecorder?.recordDeviceUnplug(udid, {
+          os: "iOS",
+          event: "detached",
+        });
         this.driver.unregisterDevice(udid);
       });
       this.listener = statusSocket;

--- a/debug_router_connector/src/device/network/NetworkDeviceManager.ts
+++ b/debug_router_connector/src/device/network/NetworkDeviceManager.ts
@@ -24,6 +24,12 @@ export default class NetworkDeviceManager extends DeviceManager {
       this.networkDeviceOpt!.ip,
       this.networkDeviceOpt!.port,
     );
+    if (!this.driver.devices.has(device.serial)) {
+      this.driver.traceRecorder?.recordDevicePlug(device.serial, {
+        os: device.info.os,
+        event: "register",
+      });
+    }
     this.driver.registerDevice(device);
   }
 }

--- a/debug_router_connector/src/index.ts
+++ b/debug_router_connector/src/index.ts
@@ -12,6 +12,10 @@ export { WatchStatus } from "./device/WatchStatus";
 export { MultiOpenCallback } from "./connector/MultiOpenCallBack";
 export { DriverReportService } from "./report/interface/DriverReportService";
 export { Client } from "./connector/Client";
+export {
+  ConnectionTraceNode,
+  ConnectionTraceOptions,
+} from "./trace/ConnectionTraceRecorder";
 
 // class
 export { UsbClient } from "./usb/Client";

--- a/debug_router_connector/src/trace/ConnectionTraceRecorder.ts
+++ b/debug_router_connector/src/trace/ConnectionTraceRecorder.ts
@@ -1,0 +1,561 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { randomUUID } from "crypto";
+import fs from "fs";
+import { defaultLogger } from "../utils/logger";
+import type { Client } from "../connector/Client";
+import { UsbClient } from "../usb/Client";
+import type { WebSocketClient } from "../websocket/WebSocketConnection";
+
+export type ConnectionTraceNode = {
+  sequence: number;
+  deviceId?: string;
+  event: string;
+  timestamp: string;
+  traceSchemaVersion: string;
+  connectionAttemptId?: string;
+  metadata?: Record<string, any>;
+};
+
+export type ConnectionTraceOptions = {
+  enabled?: boolean;
+  output?: string | NodeJS.WritableStream;
+  bufferSize?: number;
+};
+
+const TRACE_SCHEMA_VERSION = "0.1";
+const DEFAULT_TRACE_BUFFER_SIZE = 2000;
+
+type TraceListener = (node: ConnectionTraceNode) => void;
+
+interface ConnectionTraceSink {
+  write(node: ConnectionTraceNode): void;
+  close(): Promise<void>;
+}
+
+class StreamTraceSink implements ConnectionTraceSink {
+  constructor(private readonly stream: NodeJS.WritableStream) {}
+
+  write(node: ConnectionTraceNode): void {
+    this.stream.write(`${JSON.stringify(node)}\n`);
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FileTraceSink implements ConnectionTraceSink {
+  private readonly stream: fs.WriteStream;
+  private closed = false;
+  private closePromise?: Promise<void>;
+
+  constructor(path: string) {
+    this.stream = fs.createWriteStream(path, { flags: "a" });
+    this.stream.on("error", (err) => {
+      defaultLogger.warn(`connection trace write error: ${err?.message}`);
+    });
+  }
+
+  write(node: ConnectionTraceNode): void {
+    if (this.closed) {
+      return;
+    }
+    this.stream.write(`${JSON.stringify(node)}\n`);
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+    this.closed = true;
+    this.closePromise = new Promise((resolve) => {
+      if (this.stream.destroyed) {
+        resolve();
+        return;
+      }
+      this.stream.end(resolve);
+    });
+    return this.closePromise;
+  }
+}
+
+type ClientTraceInfo = {
+  deviceId?: string;
+  port?: number;
+  connectionAttemptId?: string;
+};
+
+type UsbConnectionContext = {
+  deviceId?: string;
+  port?: number;
+  clientId?: number;
+  connectionAttemptId?: string;
+};
+
+export class ConnectionTraceRecorder {
+  private readonly sink: ConnectionTraceSink;
+  private readonly maxBufferedNodes: number;
+  private nextSequenceValue = 0;
+  private connectionAttemptByPort = new Map<string, string>();
+  private usbClientConnections = new Map<number, ClientTraceInfo>();
+  private appClientConnections = new Map<number, ClientTraceInfo>();
+  private listeners = new Set<TraceListener>();
+  private recentNodes: ConnectionTraceNode[] = [];
+  private closed = false;
+  private closePromise?: Promise<void>;
+
+  constructor(
+    sink: ConnectionTraceSink,
+    maxBufferedNodes = DEFAULT_TRACE_BUFFER_SIZE,
+  ) {
+    this.sink = sink;
+    this.maxBufferedNodes = Math.max(0, maxBufferedNodes);
+  }
+
+  addListener(listener: TraceListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getRecentNodes(limit?: number): ConnectionTraceNode[] {
+    const target =
+      limit && limit > 0 ? this.recentNodes.slice(-limit) : this.recentNodes;
+    return target.map((node) => this.cloneNode(node));
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+    this.closed = true;
+    this.listeners.clear();
+    this.connectionAttemptByPort.clear();
+    this.usbClientConnections.clear();
+    this.appClientConnections.clear();
+    this.recentNodes = [];
+    this.closePromise = this.sink.close().catch((err: any) => {
+      defaultLogger.warn(`connection trace close error: ${err?.message}`);
+    });
+    return this.closePromise;
+  }
+
+  recordDevicePlug(deviceId: string, metadata?: Record<string, any>): void {
+    this.clearStaleDeviceTraceState(deviceId);
+    this.recordNode("device_plugged", deviceId, metadata);
+  }
+
+  recordDeviceUnplug(deviceId: string, metadata?: Record<string, any>): void {
+    this.recordNode("device_unplugged", deviceId, metadata);
+  }
+
+  recordDeviceRegistered(
+    deviceId: string,
+    metadata?: Record<string, any>,
+  ): void {
+    this.recordNode("device_registered", deviceId, metadata);
+  }
+
+  recordDeviceUnregistered(
+    deviceId: string,
+    metadata?: Record<string, any>,
+  ): void {
+    this.recordNode("device_unregistered", deviceId, metadata);
+  }
+
+  recordWatchClientStart(
+    deviceId: string,
+    metadata?: Record<string, any>,
+  ): void {
+    this.recordNode("client_watch_started", deviceId, metadata);
+  }
+
+  recordWatchClientStop(
+    deviceId: string,
+    metadata?: Record<string, any>,
+  ): void {
+    this.recordNode("client_watch_stopped", deviceId, metadata);
+  }
+
+  recordSocketConnected(
+    deviceId: string,
+    port: number,
+    metadata?: Record<string, any>,
+  ): string {
+    const connectionAttemptId = this.startConnectionAttempt(deviceId, port);
+    this.recordNode(
+      "socket_connected",
+      deviceId,
+      {
+        port,
+        ...metadata,
+      },
+      connectionAttemptId,
+    );
+    return connectionAttemptId;
+  }
+
+  recordSocketDisconnected(
+    deviceId: string,
+    port: number,
+    metadata?: Record<string, any>,
+    connectionAttemptId?: string,
+  ): void {
+    const resolvedConnectionAttemptId =
+      connectionAttemptId ?? this.findConnectionAttempt(deviceId, port);
+    this.recordNode(
+      "socket_disconnected",
+      deviceId,
+      {
+        port,
+        ...metadata,
+      },
+      resolvedConnectionAttemptId,
+    );
+    this.connectionAttemptByPort.delete(this.portKey(deviceId, port));
+  }
+
+  recordSdkRegister(
+    deviceId: string,
+    port: number,
+    metadata?: Record<string, any>,
+    connectionAttemptId?: string,
+  ): void {
+    const resolvedConnectionAttemptId =
+      connectionAttemptId ?? this.resolveConnectionAttempt(deviceId, port);
+    this.recordNode(
+      "sdk_register_received",
+      deviceId,
+      {
+        port,
+        ...metadata,
+      },
+      resolvedConnectionAttemptId,
+    );
+  }
+
+  recordUsbClientConnected(client: UsbClient): void {
+    const deviceId = client.deviceId();
+    const port = client.info.port;
+    const connectionAttemptId = this.resolveConnectionAttempt(deviceId, port);
+    this.recordNode(
+      "usb_client_connected",
+      deviceId,
+      {
+        clientId: client.clientId(),
+        port,
+        app: client.info.query.app,
+        os: client.info.query.os,
+        device: client.info.query.device,
+        deviceModel: client.info.query.device_model,
+        sdkVersion: client.info.query.sdk_version,
+      },
+      connectionAttemptId,
+    );
+    this.usbClientConnections.set(client.clientId(), {
+      deviceId,
+      port,
+      connectionAttemptId,
+    });
+  }
+
+  recordUsbClientDisconnected(client: UsbClient): void {
+    const deviceId = client.deviceId();
+    const port = client.info.port;
+    const entry = this.usbClientConnections.get(client.clientId());
+    const connectionAttemptId =
+      entry?.connectionAttemptId ?? this.findConnectionAttempt(deviceId, port);
+    this.recordNode(
+      "usb_client_disconnected",
+      deviceId,
+      {
+        clientId: client.clientId(),
+        port,
+        app: client.info.query.app,
+        os: client.info.query.os,
+        device: client.info.query.device,
+        deviceModel: client.info.query.device_model,
+        sdkVersion: client.info.query.sdk_version,
+      },
+      connectionAttemptId,
+    );
+    this.usbClientConnections.delete(client.clientId());
+  }
+
+  recordUsbConnectionClosed(context: UsbConnectionContext): void {
+    const clientId = context.clientId;
+    const entry = clientId
+      ? this.usbClientConnections.get(clientId)
+      : undefined;
+    const deviceId = entry?.deviceId ?? context.deviceId;
+    const port = entry?.port ?? context.port;
+    const connectionAttemptId =
+      context.connectionAttemptId ??
+      entry?.connectionAttemptId ??
+      (deviceId && port
+        ? this.findConnectionAttempt(deviceId, port)
+        : undefined);
+
+    this.recordNode(
+      "usb_connection_closed",
+      deviceId,
+      {
+        clientId,
+        port,
+      },
+      connectionAttemptId,
+    );
+  }
+
+  recordAppClientConnected(client: Client): void {
+    if (!(client instanceof UsbClient)) {
+      return;
+    }
+    const deviceId = client.deviceId();
+    const port = client.info.port;
+    const usbEntry = this.usbClientConnections.get(client.clientId());
+    const connectionAttemptId =
+      usbEntry?.connectionAttemptId ??
+      this.resolveConnectionAttempt(deviceId, port);
+
+    this.recordNode(
+      "app_client_connected",
+      deviceId,
+      {
+        clientId: client.clientId(),
+        port,
+        app: client.info.query.app,
+        os: client.info.query.os,
+        device: client.info.query.device,
+        deviceModel: client.info.query.device_model,
+        sdkVersion: client.info.query.sdk_version,
+      },
+      connectionAttemptId,
+    );
+    this.appClientConnections.set(client.clientId(), {
+      deviceId,
+      port,
+      connectionAttemptId,
+    });
+  }
+
+  recordAppClientDisconnected(clientId: number): void {
+    const entry = this.appClientConnections.get(clientId);
+    this.recordNode(
+      "app_client_disconnected",
+      entry?.deviceId,
+      {
+        clientId,
+        port: entry?.port,
+      },
+      entry?.connectionAttemptId,
+    );
+    this.appClientConnections.delete(clientId);
+  }
+
+  recordWebsocketAppClientConnected(client: WebSocketClient): void {
+    this.recordNode("websocket_app_client_connected", undefined, {
+      clientId: client.clientId(),
+      app: client.info.app,
+      deviceModel: client.info.deviceModel,
+      sdkVersion: client.info.sdkVersion,
+      osVersion: client.info.osVersion,
+      type: client.info.type,
+    });
+  }
+
+  recordWebsocketAppClientDisconnected(clientId: number): void {
+    this.recordNode("websocket_app_client_disconnected", undefined, {
+      clientId,
+    });
+  }
+
+  recordWebsocketWebClientConnected(client: WebSocketClient): void {
+    this.recordNode("websocket_web_client_connected", undefined, {
+      clientId: client.clientId(),
+      type: client.info.type,
+    });
+  }
+
+  recordWebsocketWebClientDisconnected(clientId: number): void {
+    this.recordNode("websocket_web_client_disconnected", undefined, {
+      clientId,
+    });
+  }
+
+  private recordNode(
+    event: string,
+    deviceId?: string,
+    metadata?: Record<string, any>,
+    connectionAttemptId?: string,
+  ): ConnectionTraceNode {
+    const node: ConnectionTraceNode = {
+      sequence: this.nextSequence(),
+      deviceId,
+      event,
+      timestamp: new Date().toISOString(),
+      traceSchemaVersion: TRACE_SCHEMA_VERSION,
+      connectionAttemptId,
+      metadata: this.compactMetadata(metadata),
+    };
+    if (!this.closed) {
+      try {
+        this.sink.write(node);
+      } catch (err: any) {
+        defaultLogger.warn(`connection trace write error: ${err?.message}`);
+      }
+      this.pushRecentNode(node);
+      this.emitNode(node);
+    }
+    return node;
+  }
+
+  private pushRecentNode(node: ConnectionTraceNode): void {
+    if (this.maxBufferedNodes <= 0) {
+      return;
+    }
+    this.recentNodes.push(this.cloneNode(node));
+    if (this.recentNodes.length > this.maxBufferedNodes) {
+      this.recentNodes.shift();
+    }
+  }
+
+  private emitNode(node: ConnectionTraceNode): void {
+    if (this.listeners.size === 0) {
+      return;
+    }
+    for (const listener of this.listeners) {
+      try {
+        listener(this.cloneNode(node));
+      } catch (err: any) {
+        defaultLogger.warn(`connection trace listener error: ${err?.message}`);
+      }
+    }
+  }
+
+  private cloneNode(node: ConnectionTraceNode): ConnectionTraceNode {
+    return {
+      ...node,
+      metadata: node.metadata ? { ...node.metadata } : undefined,
+    };
+  }
+
+  private startConnectionAttempt(deviceId: string, port: number): string {
+    const connectionAttemptId = randomUUID();
+    this.connectionAttemptByPort.set(
+      this.portKey(deviceId, port),
+      connectionAttemptId,
+    );
+    return connectionAttemptId;
+  }
+
+  private resolveConnectionAttempt(deviceId: string, port: number): string {
+    return (
+      this.findConnectionAttempt(deviceId, port) ??
+      this.startConnectionAttempt(deviceId, port)
+    );
+  }
+
+  private findConnectionAttempt(
+    deviceId: string,
+    port: number,
+  ): string | undefined {
+    return this.connectionAttemptByPort.get(this.portKey(deviceId, port));
+  }
+
+  private nextSequence(): number {
+    this.nextSequenceValue += 1;
+    return this.nextSequenceValue;
+  }
+
+  private portKey(deviceId: string, port: number): string {
+    return `${deviceId}:${port}`;
+  }
+
+  private compactMetadata(
+    metadata?: Record<string, any>,
+  ): Record<string, any> | undefined {
+    if (!metadata) {
+      return undefined;
+    }
+    const compacted: Record<string, any> = {};
+    for (const [key, value] of Object.entries(metadata)) {
+      if (value !== undefined) {
+        compacted[key] = value;
+      }
+    }
+    return Object.keys(compacted).length > 0 ? compacted : undefined;
+  }
+
+  private clearStaleDeviceTraceState(deviceId: string): void {
+    for (const key of this.connectionAttemptByPort.keys()) {
+      if (key.startsWith(`${deviceId}:`)) {
+        this.connectionAttemptByPort.delete(key);
+      }
+    }
+    for (const [clientId, entry] of this.usbClientConnections.entries()) {
+      if (entry.deviceId === deviceId) {
+        this.usbClientConnections.delete(clientId);
+      }
+    }
+    for (const [clientId, entry] of this.appClientConnections.entries()) {
+      if (entry.deviceId === deviceId) {
+        this.appClientConnections.delete(clientId);
+      }
+    }
+  }
+}
+
+export function createConnectionTraceRecorder(
+  options?: ConnectionTraceOptions,
+  envPath?: string,
+): ConnectionTraceRecorder | null {
+  if (options?.enabled === false) {
+    return null;
+  }
+  const output = options?.output ?? envPath;
+  if (!output) {
+    if (options?.enabled) {
+      defaultLogger.warn("connection trace enabled without output");
+    }
+    return null;
+  }
+  try {
+    if (typeof output === "string") {
+      return new ConnectionTraceRecorder(
+        new FileTraceSink(output),
+        parseTraceBufferSize(options?.bufferSize),
+      );
+    }
+    return new ConnectionTraceRecorder(
+      new StreamTraceSink(output),
+      parseTraceBufferSize(options?.bufferSize),
+    );
+  } catch (err: any) {
+    defaultLogger.warn(`connection trace init error: ${err?.message}`);
+    return null;
+  }
+}
+
+function parseTraceBufferSize(optionBufferSize?: number): number {
+  if (
+    typeof optionBufferSize === "number" &&
+    Number.isFinite(optionBufferSize) &&
+    optionBufferSize >= 0
+  ) {
+    return Math.floor(optionBufferSize);
+  }
+  const envValue = process.env.DriverConnectionTraceBufferSize;
+  if (!envValue) {
+    return DEFAULT_TRACE_BUFFER_SIZE;
+  }
+  const parsed = Number(envValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_TRACE_BUFFER_SIZE;
+  }
+  return Math.floor(parsed);
+}

--- a/debug_router_connector/src/usb/ClientAdapter.ts
+++ b/debug_router_connector/src/usb/ClientAdapter.ts
@@ -45,6 +45,7 @@ export default class ClientAdapter {
   protected connection: Connection | null = null;
   protected from?: number;
   protected id: number = 0;
+  private connectionAttemptId?: string;
   constructor(
     protected driver: DebugRouterConnector,
     protected listener: ClientEventsListener | null,
@@ -73,6 +74,16 @@ export default class ClientAdapter {
   protected handleOff(client: net.Socket) {
     this.isConnected = false;
     client.destroy();
+    this.driver.traceRecorder?.recordSocketDisconnected(
+      this.device_id,
+      this.port,
+      {
+        device: this.device,
+        os: this.type,
+      },
+      this.connectionAttemptId,
+    );
+    this.connectionAttemptId = undefined;
     if (this.listener === null) {
       defaultLogger.debug("handleOff: this.listener == null");
       return;
@@ -144,6 +155,14 @@ export default class ClientAdapter {
       event: "Initialize",
       data: -1,
     };
+    this.connectionAttemptId = this.driver.traceRecorder?.recordSocketConnected(
+      this.device_id,
+      this.port,
+      {
+        device: this.device,
+        os: this.type,
+      },
+    );
     try {
       if (this.tcpClient.writable && !this.tcpClient.destroyed) {
         defaultLogger.debug("send Initialize:" + this.port);
@@ -222,6 +241,18 @@ export default class ClientAdapter {
         sdk_version,
         raw_info: result,
       };
+      this.driver.traceRecorder?.recordSdkRegister(
+        this.device_id,
+        this.port,
+        {
+          app,
+          os: this.type,
+          device: this.device,
+          deviceModel,
+          sdkVersion: sdk_version,
+        },
+        this.connectionAttemptId,
+      );
       if (this.listener === null) {
         defaultLogger.debug(
           "handleConnection: this.listener = null:" +
@@ -229,7 +260,12 @@ export default class ClientAdapter {
         );
         return;
       }
-      this.connection = new USBConnection(this.tcpClient);
+      this.connection = new USBConnection(this.tcpClient, {
+        recorder: this.driver.traceRecorder,
+        deviceId: this.device_id,
+        port: this.port,
+        connectionAttemptId: this.connectionAttemptId,
+      });
       this.id = this.listener.onConnectionCreated(
         this.connection,
         this.port,

--- a/debug_router_connector/src/usb/ClientController.ts
+++ b/debug_router_connector/src/usb/ClientController.ts
@@ -7,6 +7,7 @@ import { BaseDevice } from "../device/BaseDevice";
 import { ClientDescription, ClientQuery } from "../utils/type";
 import ClientAdapter, { ClientEventsListener } from "./ClientAdapter";
 import { Connection } from "./Connection";
+import { USBConnection } from "./USBConnection";
 import { DebugRouterConnector } from "../connector";
 import { defaultLogger } from "../utils/logger";
 
@@ -70,11 +71,15 @@ export class ClientController implements ClientEventsListener {
     }
 
     const client = new UsbClient(info, connection);
+    if (connection instanceof USBConnection) {
+      connection.setTraceClientId(id);
+    }
 
     this.connections.set(id, client);
     // port has connected
     this.ports.set(port, true);
     this.clientInfos.set(id, port);
+    this.driver.traceRecorder?.recordUsbClientConnected(client);
     this.driver.regiserUsbClient(client);
     return id;
   }
@@ -82,6 +87,7 @@ export class ClientController implements ClientEventsListener {
   private removeConnection(id: number) {
     const client = this.connections.get(id);
     if (client) {
+      this.driver.traceRecorder?.recordUsbClientDisconnected(client);
       this.connections.delete(id);
     }
     const port = this.clientInfos.get(id);

--- a/debug_router_connector/src/usb/USBConnection.ts
+++ b/debug_router_connector/src/usb/USBConnection.ts
@@ -7,14 +7,39 @@ import { RequireMessageType, ResponseMessageType } from "../utils/type";
 import { Connection } from "./Connection";
 import { packMessage } from "./utils";
 import { defaultLogger } from "../utils/logger";
+import type { ConnectionTraceRecorder } from "../trace/ConnectionTraceRecorder";
+
+type UsbConnectionTraceContext = {
+  recorder?: ConnectionTraceRecorder | null;
+  deviceId?: string;
+  port?: number;
+  clientId?: number;
+  connectionAttemptId?: string;
+};
 
 export class USBConnection extends Connection {
-  constructor(protected socket: net.Socket) {
+  private traceContext: UsbConnectionTraceContext;
+
+  constructor(
+    protected socket: net.Socket,
+    traceContext: UsbConnectionTraceContext = {},
+  ) {
     super();
+    this.traceContext = traceContext;
+  }
+
+  setTraceClientId(clientId: number) {
+    this.traceContext = { ...this.traceContext, clientId };
   }
 
   close(): void {
     defaultLogger.debug("USBConnection: close");
+    this.traceContext.recorder?.recordUsbConnectionClosed({
+      deviceId: this.traceContext.deviceId,
+      port: this.traceContext.port,
+      clientId: this.traceContext.clientId,
+      connectionAttemptId: this.traceContext.connectionAttemptId,
+    });
     this.socket.end();
   }
 

--- a/docs/connection_trace.md
+++ b/docs/connection_trace.md
@@ -1,0 +1,247 @@
+# DebugRouterConnector connection trace
+
+## Overview
+
+DebugRouterConnector can emit an append-only JSONL trace for connection
+lifecycle events. The trace is intended for maintainers to restore the actual scene.
+
+The recorder writes flat facts. These facts can be reconstructed into tree, grouped session, or diagnostic view by a trace analyzer tool.
+
+Use the trace to answer questions such as:
+
+- Was a device detected and registered by the connector?
+- Which socket attempt actually received an SDK register message?
+
+## Enabling trace output
+
+Trace output can be enabled through the connector constructor:
+
+```ts
+import { DebugRouterConnector } from "@lynx-js/debug-router-connector";
+
+const connector = new DebugRouterConnector({
+  connectionTrace: {
+    enabled: true,
+    output: "/tmp/debug-router-trace.jsonl",
+    bufferSize: 5000,
+  },
+});
+```
+
+It can also be enabled with the `DriverConnectionTracePath` environment
+variable:
+
+```sh
+DriverConnectionTracePath=/tmp/debug-router-trace.jsonl node app.js
+```
+
+Recent in-memory records are available from the connector:
+
+```ts
+const records = connector.getConnectionTrace(2000);
+```
+
+Live records can be consumed with a listener:
+
+```ts
+const unsubscribe = connector.onConnectionTrace((record) => {
+  traceQueue.push(record);
+});
+
+unsubscribe();
+```
+
+When a connector instance is no longer needed, close it so file trace output is
+flushed and the owned trace sink is released:
+
+```ts
+await connector.close();
+```
+
+## JSONL record schema
+
+Each output line is one complete JSON object. The current trace schema version is
+`0.1`.
+
+```ts
+type ConnectionTraceRecord = {
+  sequence: number;
+  deviceId?: string;
+  event: string;
+  timestamp: string;
+  traceSchemaVersion: "0.1";
+  connectionAttemptId?: string;
+  metadata?: Record<string, unknown>;
+};
+```
+
+Common fields:
+
+- `sequence`: Monotonically increasing number assigned by one recorder instance.
+  Use it as the primary ordering field inside one trace file.
+- `timestamp`: ISO timestamp captured when the record is emitted.
+- `event`: Event name.
+- `traceSchemaVersion`: Schema version for the record.
+- `deviceId`: Connector-local device identifier when known. For Android this is
+  usually the adb serial. Treat it as a correlation field, not as a globally
+  stable identity.
+- `connectionAttemptId`: UUID generated for one socket or transport attempt.
+  It is created when `socket_connected` is recorded and reused by later events
+  on the same attempt.
+- `metadata`: Event-specific details such as `port`, `clientId`, `app`, `os`,
+  `device`, `deviceModel`, and `sdkVersion`.
+
+Compatibility note: schema `0.1` does not emit recorder-managed tree or session
+fields such as `id`, `parentId`, `logicalSessionKey`, `traceSource`, or
+`appSignature`.
+
+## Event reference
+
+| Event | Meaning |
+| --- | --- |
+| `device_plugged` | The platform device watcher observed a physical or daemon-level device attach/change event. |
+| `device_unplugged` | The platform device watcher observed a physical or daemon-level device detach/offline event. |
+| `device_registered` | The connector added the device to its device map and made it available to connector consumers. |
+| `device_unregistered` | The connector removed the device from its device map. Socket and client teardown may still emit records after this event. |
+| `client_watch_started` | The connector started watching candidate client ports for one device. |
+| `client_watch_stopped` | The connector stopped the current client watch loop for one device. |
+| `socket_connected` | A socket probe or transport connection succeeded. This does not mean the mobile SDK has registered. |
+| `socket_disconnected` | A socket probe or transport connection closed or errored. |
+| `sdk_register_received` | The connector received the SDK `Register` message. This is the first record that proves the socket speaks the debug-router protocol. |
+| `usb_client_connected` | The connector created an internal `UsbClient` for a registered SDK connection. |
+| `usb_client_disconnected` | The internal `UsbClient` was removed. |
+| `usb_connection_closed` | The lower-level USB connection wrapper was closed. |
+| `app_client_connected` | The registered USB client was emitted as an app client and is visible to connector consumers. |
+| `app_client_disconnected` | The app client was removed from the consumer-visible client set. |
+| `websocket_app_client_connected` | A WebSocket app client connected. |
+| `websocket_app_client_disconnected` | A WebSocket app client disconnected. |
+| `websocket_web_client_connected` | A WebSocket web client connected. |
+| `websocket_web_client_disconnected` | A WebSocket web client disconnected. |
+
+## USB connection timeline
+
+Android USB connection normally probes multiple forwarded ports. A successful
+socket probe is only a transport-level fact. The effective SDK connection is the
+attempt that later emits `sdk_register_received`.
+
+Compact example:
+
+```jsonl
+{"sequence":1,"deviceId":"android-serial-01","event":"device_plugged","timestamp":"2026-05-06T08:47:40.903Z","traceSchemaVersion":"0.1","metadata":{"os":"Android","event":"change","deviceType":"device"}}
+{"sequence":2,"deviceId":"android-serial-01","event":"device_registered","timestamp":"2026-05-06T08:47:40.965Z","traceSchemaVersion":"0.1","metadata":{"os":"Android","title":"Pixel-7"}}
+{"sequence":3,"deviceId":"android-serial-01","event":"client_watch_started","timestamp":"2026-05-06T08:48:04.825Z","traceSchemaVersion":"0.1","metadata":{"os":"Android","title":"Pixel-7"}}
+{"sequence":4,"deviceId":"android-serial-01","event":"socket_connected","timestamp":"2026-05-06T08:48:04.826Z","traceSchemaVersion":"0.1","connectionAttemptId":"0d7d5964-9d20-4df1-bbb9-00f815818111","metadata":{"port":13001,"device":"Pixel-7","os":"Android"}}
+{"sequence":5,"deviceId":"android-serial-01","event":"socket_connected","timestamp":"2026-05-06T08:48:04.827Z","traceSchemaVersion":"0.1","connectionAttemptId":"1cb52755-33a2-4f49-9059-af601f98c222","metadata":{"port":13101,"device":"Pixel-7","os":"Android"}}
+{"sequence":6,"deviceId":"android-serial-01","event":"socket_connected","timestamp":"2026-05-06T08:48:04.828Z","traceSchemaVersion":"0.1","connectionAttemptId":"2fba8226-5b1e-4b55-88c8-e6f21bb91333","metadata":{"port":13201,"device":"Pixel-7","os":"Android"}}
+{"sequence":7,"deviceId":"android-serial-01","event":"socket_disconnected","timestamp":"2026-05-06T08:48:04.835Z","traceSchemaVersion":"0.1","connectionAttemptId":"0d7d5964-9d20-4df1-bbb9-00f815818111","metadata":{"port":13001,"device":"Pixel-7","os":"Android"}}
+{"sequence":8,"deviceId":"android-serial-01","event":"sdk_register_received","timestamp":"2026-05-06T08:48:04.857Z","traceSchemaVersion":"0.1","connectionAttemptId":"2fba8226-5b1e-4b55-88c8-e6f21bb91333","metadata":{"port":13201,"app":"com.example.demo","os":"Android","device":"Pixel-7","deviceModel":"Pixel 7","sdkVersion":"1.0.0"}}
+{"sequence":9,"deviceId":"android-serial-01","event":"usb_client_connected","timestamp":"2026-05-06T08:48:04.857Z","traceSchemaVersion":"0.1","connectionAttemptId":"2fba8226-5b1e-4b55-88c8-e6f21bb91333","metadata":{"clientId":3,"port":13201,"app":"com.example.demo","os":"Android","device":"Pixel-7","deviceModel":"Pixel 7","sdkVersion":"1.0.0"}}
+{"sequence":10,"deviceId":"android-serial-01","event":"app_client_connected","timestamp":"2026-05-06T08:48:04.857Z","traceSchemaVersion":"0.1","connectionAttemptId":"2fba8226-5b1e-4b55-88c8-e6f21bb91333","metadata":{"clientId":3,"port":13201,"app":"com.example.demo","os":"Android","device":"Pixel-7","deviceModel":"Pixel 7","sdkVersion":"1.0.0"}}
+{"sequence":11,"deviceId":"android-serial-01","event":"client_watch_stopped","timestamp":"2026-05-06T08:48:04.857Z","traceSchemaVersion":"0.1","metadata":{"os":"Android","title":"Pixel-7"}}
+```
+
+In this example, three socket attempts were opened. Attempt
+`0d7d5964-9d20-4df1-bbb9-00f815818111` disconnected without SDK
+registration. Attempt `2fba8226-5b1e-4b55-88c8-e6f21bb91333` received
+`sdk_register_received` and became the effective app client connection. Attempt
+`1cb52755-33a2-4f49-9059-af601f98c222` is a transport-level probe that did not
+register within the example window.
+
+## How to correlate records
+
+- Use `sequence` to reconstruct the recorder-local timeline.
+- Use `deviceId` to group records for one connector-visible device.
+- Use `connectionAttemptId` to group the records for one socket or transport
+  attempt.
+- Treat `sdk_register_received` as the boundary between a generic socket probe
+  and a protocol-valid mobile SDK connection.
+- Use `clientId` only after `usb_client_connected` or `app_client_connected`.
+  It is assigned by the connector and is not stable across connector processes.
+- Use `app`, `deviceModel`, `sdkVersion`, and other SDK-provided metadata as
+  diagnostic labels. They are useful for display and filtering, but they are not
+  guaranteed unique.
+- Expect disconnect records to arrive after `device_unplugged` or
+  `device_unregistered`. Device detection and socket/client teardown are
+  asynchronous.
+
+## Analyzer responsibilities
+
+A trace analyzer should build diagnostic views from the flat JSONL records
+without requiring the recorder to maintain derived structure. Useful views
+include:
+
+- Timeline view sorted by `sequence`.
+- Device view grouped by `deviceId`.
+- Connection-attempt view grouped by `connectionAttemptId`.
+- Client view grouped by `clientId` after client creation.
+- Protocol-success view that highlights attempts with
+  `sdk_register_received`.
+- Merged connector and SDK view once SDK-side tracing reports the same
+  connection attempt identity.
+
+Analyzers should tolerate partial traces. A file may end while sockets are still
+open, while a device is still attached, or before async disconnect events have
+arrived.
+
+## Implementation notes
+
+- `connectionAttemptId` is generated in the connector with
+  `crypto.randomUUID()` when `socket_connected` is recorded.
+- The recorder keeps only minimal runtime caches needed to fill later disconnect
+  records with `deviceId`, `port`, and `connectionAttemptId`.
+- Android devices normally have multiple candidate remote ports starting at
+  `8901`. The connector forwards them to available local ports and probes each
+  local port during client discovery.
+- iOS uses usbmux tunneling instead of adb forwarding, but the trace still uses
+  the same flat record model and connection-attempt correlation.
+- WebSocket events are recorded in the same stream, but they do not normally
+  carry USB-specific fields such as `deviceId`, `port`, or
+  `connectionAttemptId`.
+
+## Automated checks
+
+The connector trace checks live under `test/e2e_test/connector_test`. They are
+integration-level smoke tests for `DebugRouterConnector`; they intentionally use
+public connector APIs instead of unit-level assertions over private recorder
+classes.
+
+Install the local package dependency before running them:
+
+```sh
+cd test/e2e_test/connector_test
+npm install
+```
+
+Run the no-device checks with:
+
+```sh
+npm run test:without-device
+```
+
+This mode verifies:
+
+- Device-manager-disabled behavior: `connectDevices()` and
+  `connectUsbClients()` return empty results without throwing.
+- A local fake app server through `NetworkDevice`: the connector discovers the
+  network device, opens a socket, receives `Register`, creates a `UsbClient`,
+  sends one public client message, and records connection trace events.
+
+Run real-device checks with one of:
+
+```sh
+npm run test:with-device
+npm run test:with-device:android
+npm run test:with-device:ios
+npm run test:with-device:harmony
+```
+
+`test:with-device` enables all supported mobile device managers. The platform
+specific scripts restrict discovery to one platform. Real-device mode requires a
+phone with the DebugRouter test app available. The Android script launches
+`com.lynx.debugrouter.testapp/.MainActivity` by default; pass
+`-- --no-launch-app` if the app is already running or a different app is being
+used.
+
+The real-device check verifies physical discovery, USB client registration,
+public connector events, and trace integration. It does not duplicate the
+existing large-message or frontend WebSocket routing scripts.

--- a/test/e2e_test/connector_test/debug_router_connector_auto_test.js
+++ b/test/e2e_test/connector_test/debug_router_connector_auto_test.js
@@ -1,0 +1,624 @@
+const assert = require("assert");
+const childProcess = require("child_process");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+
+const {
+  DebugRouterConnector,
+} = require("@lynx-js/debug-router-connector");
+
+const DEFAULT_ANDROID_ACTIVITY =
+  "com.lynx.debugrouter.testapp/com.lynx.debugrouter.testapp.MainActivity";
+const DEFAULT_DEVICE_TIMEOUT = 6000;
+const DEFAULT_CLIENT_TIMEOUT = 6000;
+
+function parseArgs(argv) {
+  const args = {
+    mode: "no-device",
+    platform: "android",
+    serial: "",
+    deviceTimeout: DEFAULT_DEVICE_TIMEOUT,
+    clientTimeout: DEFAULT_CLIENT_TIMEOUT,
+    androidActivity: DEFAULT_ANDROID_ACTIVITY,
+    launchAndroidApp: true,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const readValue = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      i++;
+      return value;
+    };
+
+    if (arg === "--mode") {
+      args.mode = readValue();
+    } else if (arg === "--platform") {
+      args.platform = readValue();
+    } else if (arg === "--serial") {
+      args.serial = readValue();
+    } else if (arg === "--device-timeout") {
+      args.deviceTimeout = Number(readValue());
+    } else if (arg === "--client-timeout") {
+      args.clientTimeout = Number(readValue());
+    } else if (arg === "--android-activity") {
+      args.androidActivity = readValue();
+    } else if (arg === "--no-launch-app") {
+      args.launchAndroidApp = false;
+    } else if (arg === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!["no-device", "real-device"].includes(args.mode)) {
+    throw new Error(`Unsupported --mode: ${args.mode}`);
+  }
+  if (!["android", "ios", "harmony", "all"].includes(args.platform)) {
+    throw new Error(`Unsupported --platform: ${args.platform}`);
+  }
+  if (!Number.isFinite(args.deviceTimeout) || args.deviceTimeout <= 0) {
+    throw new Error("--device-timeout must be a positive number");
+  }
+  if (!Number.isFinite(args.clientTimeout) || args.clientTimeout <= 0) {
+    throw new Error("--client-timeout must be a positive number");
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  node debug_router_connector_auto_test.js --mode no-device
+  node debug_router_connector_auto_test.js --mode real-device --platform android
+
+Modes:
+  no-device    Runs without phones. Verifies empty discovery and a local
+               NetworkDevice handshake through the public connector API.
+  real-device  Requires a phone with the DebugRouter test app. Verifies physical
+               device discovery, USB client registration, public events, and
+               connection trace integration.
+
+Options:
+  --platform android|ios|harmony|all
+  --serial <device serial or UDID>
+  --device-timeout <ms>
+  --client-timeout <ms>
+  --android-activity <package/activity>
+  --no-launch-app
+`);
+}
+
+function logStep(message) {
+  console.log(`[connector-auto-test] ${message}`);
+}
+
+function withTimeout(promise, timeout, label) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout after ${timeout}ms: ${label}`));
+    }, timeout);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function waitFor(check, timeout, label, interval = 50) {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      try {
+        if (check()) {
+          resolve();
+          return;
+        }
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      if (Date.now() - startedAt >= timeout) {
+        reject(new Error(`Timeout after ${timeout}ms: ${label}`));
+        return;
+      }
+      setTimeout(tick, interval);
+    };
+    tick();
+  });
+}
+
+function exec(command, timeout) {
+  return new Promise((resolve, reject) => {
+    const child = childProcess.exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timeout:${timeout} exec:${command}`));
+    }, timeout);
+    child.on("exit", () => clearTimeout(timer));
+  });
+}
+
+function makeTempTracePath(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  return {
+    dir,
+    tracePath: path.join(dir, "connection-trace.jsonl"),
+  };
+}
+
+function packMessage(message) {
+  const payload = Buffer.from(JSON.stringify(message), "utf8");
+  const header = Buffer.alloc(20);
+  header.writeUInt32BE(1, 0);
+  header.writeUInt32BE(101, 4);
+  header.writeUInt32BE(0, 8);
+  header.writeUInt32BE(payload.length + 4, 12);
+  header.writeUInt32BE(payload.length, 16);
+  return Buffer.concat([header, payload]);
+}
+
+function createFrameParser(onMessage) {
+  let buffered = Buffer.alloc(0);
+  return (chunk) => {
+    buffered = Buffer.concat([buffered, chunk]);
+    while (buffered.length >= 20) {
+      const payloadSize = buffered.readUInt32BE(16);
+      const frameSize = 20 + payloadSize;
+      if (buffered.length < frameSize) {
+        return;
+      }
+      const payload = buffered.slice(20, frameSize).toString("utf8");
+      buffered = buffered.slice(frameSize);
+      onMessage(JSON.parse(payload));
+    }
+  };
+}
+
+async function startFakeDebugRouterAppServer() {
+  const sockets = new Set();
+  const receivedMessages = [];
+  const appName = "connector-auto-test-app";
+
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on(
+      "data",
+      createFrameParser((message) => {
+        receivedMessages.push(message);
+        if (message.event === "Initialize") {
+          socket.write(
+            packMessage({
+              event: "Register",
+              data: {
+                id: message.data,
+                info: {
+                  App: appName,
+                  sdkVersion: "auto-test",
+                  deviceModel: "FakeNetworkDevice",
+                  osVersion: process.platform,
+                },
+              },
+            }),
+          );
+          return;
+        }
+
+        if (message.event === "Customized") {
+          const requestMessage = message.data?.data?.message ?? {};
+          socket.write(
+            packMessage({
+              event: "Customized",
+              data: {
+                type: message.data?.type ?? "App",
+                data: {
+                  client_id: message.data?.data?.client_id ?? -1,
+                  session_id: message.data?.data?.session_id ?? -1,
+                  message: JSON.stringify({
+                    id: requestMessage.id,
+                    result: {
+                      ok: true,
+                      method: requestMessage.method,
+                      params: requestMessage.params,
+                    },
+                  }),
+                },
+                sender: -1,
+              },
+            }),
+          );
+        }
+      }),
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  return {
+    appName,
+    port: server.address().port,
+    receivedMessages,
+    close: () =>
+      new Promise((resolve) => {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function getTraceEvents(driver) {
+  return driver.getConnectionTrace().map((node) => node.event);
+}
+
+function assertTraceIncludes(driver, expectedEvents) {
+  const events = getTraceEvents(driver);
+  for (const event of expectedEvents) {
+    assert(
+      events.includes(event),
+      `Expected trace event "${event}", got: ${events.join(", ")}`,
+    );
+  }
+}
+
+function assertFlatTraceShape(driver) {
+  const trace = driver.getConnectionTrace();
+  let previousSequence = 0;
+  for (const node of trace) {
+    assert.strictEqual(node.traceSchemaVersion, "0.1");
+    assert.strictEqual(typeof node.sequence, "number");
+    assert(
+      node.sequence > previousSequence,
+      `Expected trace sequence to increase, got ${previousSequence} then ${node.sequence}`,
+    );
+    assert(
+      !Object.prototype.hasOwnProperty.call(node, "id"),
+      "Trace node should not include record-time tree id",
+    );
+    assert(
+      !Object.prototype.hasOwnProperty.call(node, "parentId"),
+      "Trace node should not include record-time parentId",
+    );
+    previousSequence = node.sequence;
+  }
+}
+
+function assertConnectionAttemptIds(driver, expectedEvents) {
+  const trace = driver.getConnectionTrace();
+  for (const event of expectedEvents) {
+    const nodes = trace.filter((node) => node.event === event);
+    assert(nodes.length > 0, `Expected trace event "${event}"`);
+    for (const node of nodes) {
+      assert(
+        typeof node.connectionAttemptId === "string" &&
+          node.connectionAttemptId.length > 0,
+        `Expected ${event} to include connectionAttemptId`,
+      );
+    }
+  }
+}
+
+function assertFakeFlowUsesOneConnectionAttempt(driver) {
+  const trace = driver.getConnectionTrace();
+  const registerNode = trace.find(
+    (node) => node.event === "sdk_register_received",
+  );
+  assert(registerNode, "Expected sdk_register_received in trace");
+  const connectionAttemptId = registerNode.connectionAttemptId;
+  for (const event of ["usb_client_connected", "app_client_connected"]) {
+    const node = trace.find((item) => item.event === event);
+    assert(node, `Expected ${event} in trace`);
+    assert.strictEqual(node.connectionAttemptId, connectionAttemptId);
+  }
+}
+
+async function runEmptyDiscoveryCheck() {
+  logStep("checking connector behavior with no device managers enabled");
+  const driver = new DebugRouterConnector({
+    manualConnect: true,
+    enableWebSocket: false,
+    enableAndroid: false,
+    enableIOS: false,
+    enableHarmony: false,
+    enableDesktop: false,
+    enableNetworkDevice: false,
+  });
+
+  try {
+    const devices = await driver.connectDevices(100);
+    assert.deepStrictEqual(devices, []);
+
+    const clients = await driver.connectUsbClients("missing-device", 100, false);
+    assert.deepStrictEqual(clients, []);
+    assert.deepStrictEqual(driver.getConnectionTrace(), []);
+  } finally {
+    await driver.close();
+  }
+}
+
+async function runFakeNetworkCheck() {
+  logStep("checking no-device end-to-end flow with a local NetworkDevice");
+  const fakeApp = await startFakeDebugRouterAppServer();
+  const { dir, tracePath } = makeTempTracePath("debug-router-no-device");
+  const liveTraceEvents = [];
+  let driver;
+  let unsubscribe = () => {};
+
+  try {
+    driver = new DebugRouterConnector({
+      manualConnect: true,
+      enableWebSocket: false,
+      enableAndroid: false,
+      enableIOS: false,
+      enableHarmony: false,
+      enableDesktop: false,
+      enableNetworkDevice: true,
+      networkDeviceOpt: {
+        ip: "127.0.0.1",
+        port: [fakeApp.port],
+      },
+      connectionTrace: {
+        enabled: true,
+        output: tracePath,
+        bufferSize: 100,
+      },
+    });
+
+    unsubscribe = driver.onConnectionTrace((node) => {
+      liveTraceEvents.push(node.event);
+    });
+
+    const devices = await driver.connectDevices(1000);
+    assert.strictEqual(devices.length, 1);
+    assert.strictEqual(devices[0].serial, "127.0.0.1");
+
+    const clients = await driver.connectUsbClients(
+      devices[0].serial,
+      4000,
+      false,
+    );
+    assert.strictEqual(clients.length, 1);
+    assert.strictEqual(clients[0].info.query.app, fakeApp.appName);
+    assert.strictEqual(driver.getAllUsbClients().length, 1);
+
+    const nonce = `nonce-${Date.now()}`;
+    const response = await withTimeout(
+      clients[0].sendClientMessage("ConnectorAutoTest.Ping", { nonce }),
+      3000,
+      "fake app ping response",
+    );
+    const payload = JSON.parse(response);
+    assert.deepStrictEqual(payload.result, {
+      ok: true,
+      method: "ConnectorAutoTest.Ping",
+      params: { nonce },
+    });
+
+    await waitFor(
+      () => fakeApp.receivedMessages.some((msg) => msg.event === "Customized"),
+      1000,
+      "fake app receiving customized message",
+    );
+
+    assertTraceIncludes(driver, [
+      "device_plugged",
+      "device_registered",
+      "client_watch_started",
+      "socket_connected",
+      "sdk_register_received",
+      "usb_client_connected",
+      "app_client_connected",
+    ]);
+    assertFlatTraceShape(driver);
+    assertConnectionAttemptIds(driver, [
+      "socket_connected",
+      "sdk_register_received",
+      "usb_client_connected",
+      "app_client_connected",
+    ]);
+    assertFakeFlowUsesOneConnectionAttempt(driver);
+    assert(
+      liveTraceEvents.includes("usb_client_connected"),
+      `Expected live trace to include usb_client_connected, got: ${liveTraceEvents.join(
+        ", ",
+      )}`,
+    );
+
+    await waitFor(
+      () =>
+        fs.existsSync(tracePath) &&
+        fs.readFileSync(tracePath, "utf8").includes("usb_client_connected"),
+      2000,
+      "trace file flush",
+    );
+
+    unsubscribe();
+  } finally {
+    unsubscribe();
+    await driver?.close();
+    await fakeApp.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function platformOptions(platform) {
+  return {
+    enableAndroid: platform === "android" || platform === "all",
+    enableIOS: platform === "ios" || platform === "all",
+    enableHarmony: platform === "harmony" || platform === "all",
+  };
+}
+
+function isDeviceForPlatform(device, platform) {
+  if (platform === "all") {
+    return true;
+  }
+  if (platform === "android") {
+    return device.info.os === "Android";
+  }
+  if (platform === "ios") {
+    return device.info.os === "iOS";
+  }
+  if (platform === "harmony") {
+    return device.info.os === "Harmony";
+  }
+  return false;
+}
+
+async function launchAndroidAppIfNeeded(args, device) {
+  if (
+    !args.launchAndroidApp ||
+    args.platform !== "android" ||
+    device.info.os !== "Android"
+  ) {
+    return;
+  }
+  const serialArg = args.serial || device.serial;
+  const serialPrefix = serialArg ? `-s ${serialArg} ` : "";
+  const command = `adb ${serialPrefix}shell am start -n ${args.androidActivity} --es connection_type usb`;
+  logStep(`launching Android test app: ${command}`);
+  await exec(command, 10000);
+}
+
+async function runRealDeviceScenario(args) {
+  logStep(`checking real-device flow for platform=${args.platform}`);
+  const { dir, tracePath } = makeTempTracePath("debug-router-real-device");
+  const flags = platformOptions(args.platform);
+  const liveTraceEvents = [];
+  let driver;
+
+  try {
+    driver = new DebugRouterConnector({
+      manualConnect: true,
+      enableWebSocket: false,
+      enableAndroid: flags.enableAndroid,
+      enableIOS: flags.enableIOS,
+      enableHarmony: flags.enableHarmony,
+      enableDesktop: false,
+      enableNetworkDevice: false,
+      connectionTrace: {
+        enabled: true,
+        output: tracePath,
+        bufferSize: 500,
+      },
+    });
+
+    driver.onConnectionTrace((node) => {
+      liveTraceEvents.push(node.event);
+    });
+
+    const devices = await driver.connectDevices(
+      args.deviceTimeout,
+      args.serial || null,
+    );
+    const candidates = devices.filter((device) =>
+      isDeviceForPlatform(device, args.platform),
+    );
+    assert(
+      candidates.length > 0,
+      `Expected at least one ${args.platform} device, got: ${devices
+        .map((device) => `${device.serial}(${device.info.os})`)
+        .join(", ")}`,
+    );
+
+    const device = candidates[0];
+    await launchAndroidAppIfNeeded(args, device);
+
+    const clients = await driver.connectUsbClients(
+      device.serial,
+      args.clientTimeout,
+      false,
+    );
+    assert(
+      clients.length > 0,
+      `Expected at least one USB client for ${device.serial}. Make sure the DebugRouter test app is installed and running.`,
+    );
+
+    const client = clients[0];
+    assert(client.clientId() > 0, "client id should be assigned by connector");
+    assert.strictEqual(client.deviceId(), device.serial);
+    assert(client.info.query.app, "client app name should be present");
+    assert.strictEqual(driver.getAllUsbClients().length, clients.length);
+
+    assertTraceIncludes(driver, [
+      "device_registered",
+      "client_watch_started",
+      "socket_connected",
+      "sdk_register_received",
+      "usb_client_connected",
+      "app_client_connected",
+    ]);
+    assertFlatTraceShape(driver);
+    assertConnectionAttemptIds(driver, [
+      "socket_connected",
+      "sdk_register_received",
+      "usb_client_connected",
+      "app_client_connected",
+    ]);
+    assert(
+      liveTraceEvents.includes("usb_client_connected"),
+      `Expected live trace to include usb_client_connected, got: ${liveTraceEvents.join(
+        ", ",
+      )}`,
+    );
+
+    await waitFor(
+      () =>
+        fs.existsSync(tracePath) &&
+        fs.readFileSync(tracePath, "utf8").includes("sdk_register_received"),
+      2000,
+      "real-device trace file flush",
+    );
+
+    logStep(
+      `connected ${device.serial} (${device.info.os}) client=${client.clientId()} app=${client.info.query.app}`,
+    );
+  } finally {
+    await driver?.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.mode === "no-device") {
+    await runEmptyDiscoveryCheck();
+    await runFakeNetworkCheck();
+  } else {
+    await runRealDeviceScenario(args);
+  }
+  logStep("TEST SUCCESS");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("[connector-auto-test] TEST FAILED");
+    console.error(error && error.stack ? error.stack : error);
+    process.exit(1);
+  });

--- a/test/e2e_test/connector_test/package.json
+++ b/test/e2e_test/connector_test/package.json
@@ -4,7 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test:without-device",
+    "test:without-device": "node debug_router_connector_auto_test.js --mode no-device",
+    "test:with-device": "node debug_router_connector_auto_test.js --mode real-device --platform all",
+    "test:with-device:android": "node debug_router_connector_auto_test.js --mode real-device --platform android",
+    "test:with-device:ios": "node debug_router_connector_auto_test.js --mode real-device --platform ios --no-launch-app",
+    "test:with-device:harmony": "node debug_router_connector_auto_test.js --mode real-device --platform harmony --no-launch-app"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Introduce ConnectionTraceRecorder with a configurable sink (file path or writable stream) that records the full USB/WebSocket connection lifecycle as a tree of JSON-line nodes.

Each device plug-in event creates a root node; subsequent stages (device_registered, client_watch_started, socket_connected, register_received, usb_client_connected, app_client_connected, websocket_*_client_connected, socket_disconnected, etc.) are recorded as child nodes with parent references, forming a traceable tree per device.

Key changes:
- src/trace/ConnectionTraceRecorder.ts: new recorder + sink abstraction
- devOption.connectionTrace: opt-in via {enabled, output} or env DriverConnectionTracePath (default off, no behavior change)
- AndroidDeviceManager / iOSDeviceManager / HarmonyDeviceManager / NetworkDeviceManager: record device_plugged / device_unplugged roots
- DebugRouterConnector.registerDevice / unregisterDevice: record device_registered / device_unregistered
- BaseDevice.startWatchClient / stopWatchClient: record watch lifecycle
- ClientAdapter.onConnect / handleOff / handleConnection: record socket_connected, socket_disconnected, register_received
- ClientController.addConnection / removeConnection: record usb_client_connected / usb_client_disconnected
- USBConnection.close: record usb_connection_closed
- DebugRouterConnector.emit: record app/websocket client connect/disconnect
- README.md: document connectionTrace option