### PR TITLE
[Feature] Add debugChannel APIs and coalesce server start/stop

### DIFF
--- a/debug_router/android/debug_router/src/main/java/com/lynx/debugrouter/DebugRouter.java
+++ b/debug_router/android/debug_router/src/main/java/com/lynx/debugrouter/DebugRouter.java
@@ -454,11 +454,30 @@ public class DebugRouter {
 
   private native void nativeEnableSingleSession(int session_id);
 
+  private native void nativeEnableDebugChannel();
+
+  private native void nativeDisableDebugChannel();
+
+  private native boolean nativeIsDebugChannelEnabled();
+
   public void enableAllSessions() {
     nativeEnableAllSessions();
   }
 
+  // session_id must be > 0. Invalid values are ignored by native layer.
   public void enableSingleSession(int session_id) {
     nativeEnableSingleSession(session_id);
+  }
+
+  public void enableDebugChannel() {
+    nativeEnableDebugChannel();
+  }
+
+  public void disableDebugChannel() {
+    nativeDisableDebugChannel();
+  }
+
+  public boolean isDebugChannelEnabled() {
+    return nativeIsDebugChannelEnabled();
   }
 }

--- a/debug_router/common/debug_router.cc
+++ b/debug_router/common/debug_router.cc
@@ -203,5 +203,17 @@ void DebugRouter::EnableSingleSession(int32_t session_id) {
   core::DebugRouterCore::GetInstance().EnableSingleSession(session_id);
 }
 
+void DebugRouter::EnableDebugChannel() {
+  core::DebugRouterCore::GetInstance().EnableDebugChannel();
+}
+
+void DebugRouter::DisableDebugChannel() {
+  core::DebugRouterCore::GetInstance().DisableDebugChannel();
+}
+
+bool DebugRouter::IsDebugChannelEnabled() {
+  return core::DebugRouterCore::GetInstance().IsDebugChannelEnabled();
+}
+
 }  // namespace common
 }  // namespace debugrouter

--- a/debug_router/common/debug_router.h
+++ b/debug_router/common/debug_router.h
@@ -84,7 +84,11 @@ class DEBUG_ROUTER_EXPORT DebugRouter {
       const std::shared_ptr<DebugRouterStateListener> &listener);
 
   void EnableAllSessions();
+  // session_id must be > 0.
   void EnableSingleSession(int32_t session_id);
+  void EnableDebugChannel();
+  void DisableDebugChannel();
+  bool IsDebugChannelEnabled();
 
   DebugRouter(const DebugRouter &) = delete;
   DebugRouter &operator=(const DebugRouter &) = delete;

--- a/debug_router/harmony/debug_router/src/main/ets/DebugRouter.ets
+++ b/debug_router/harmony/debug_router/src/main/ets/DebugRouter.ets
@@ -124,7 +124,20 @@ export class DebugRouter {
     DebugRouterHarmony.enableAllSessions();
   }
 
+  // sessionId must be > 0. Invalid values are ignored by native layer.
   public static enableSingleSession(sessionId: number): void {
     DebugRouterHarmony.enableSingleSession(sessionId);
+  }
+
+  public static enableDebugChannel(): void {
+    DebugRouterHarmony.enableDebugChannel();
+  }
+
+  public static disableDebugChannel(): void {
+    DebugRouterHarmony.disableDebugChannel();
+  }
+
+  public static isDebugChannelEnabled(): boolean {
+    return DebugRouterHarmony.isDebugChannelEnabled();
   }
 }

--- a/debug_router/harmony/debug_router/src/main/ets/types/libdebugrouter/index.d.ts
+++ b/debug_router/harmony/debug_router/src/main/ets/types/libdebugrouter/index.d.ts
@@ -56,6 +56,10 @@ export declare class DebugRouterHarmony {
   static getAppInfoByKey: (key:string) => string;
   
   static enableAllSessions: () => void;
+  /** sessionId must be > 0. Invalid values are ignored by native layer. */
   static enableSingleSession: (sessionId: number) => void;
+  static enableDebugChannel: () => void;
+  static disableDebugChannel: () => void;
+  static isDebugChannelEnabled: () => boolean;
 }
  

--- a/debug_router/ios/DebugRouter.mm
+++ b/debug_router/ios/DebugRouter.mm
@@ -645,4 +645,16 @@ class MessageHandlerDelegate : public debugrouter::core::DebugRouterMessageHandl
   debugrouter::core::DebugRouterCore::GetInstance().EnableSingleSession(sessionId);
 }
 
+- (void)enableDebugChannel {
+  debugrouter::core::DebugRouterCore::GetInstance().EnableDebugChannel();
+}
+
+- (void)disableDebugChannel {
+  debugrouter::core::DebugRouterCore::GetInstance().DisableDebugChannel();
+}
+
+- (BOOL)isDebugChannelEnabled {
+  return debugrouter::core::DebugRouterCore::GetInstance().IsDebugChannelEnabled();
+}
+
 @end

--- a/debug_router/ios/public/DebugRouter.h
+++ b/debug_router/ios/public/DebugRouter.h
@@ -103,6 +103,10 @@ typedef enum : NSUInteger { ConnectionTypeWebSocket, ConnectionTypeUSB, Unknown 
 - (nonnull NSString *)getAppInfoByKey:(nonnull NSString *)key;
 
 - (void)enableAllSessions;
+// sessionId must be > 0. Invalid values are ignored.
 - (void)enableSingleSession:(int)sessionId;
+- (void)enableDebugChannel;
+- (void)disableDebugChannel;
+- (BOOL)isDebugChannelEnabled;
 
 @end

--- a/debug_router/native/android/debug_router_android.cc
+++ b/debug_router/native/android/debug_router_android.cc
@@ -190,6 +190,19 @@ void EnableSingleSession(JNIEnv *env, jobject jcaller, jint session_id) {
       session_id);
 }
 
+void EnableDebugChannel(JNIEnv *env, jobject jcaller) {
+  debugrouter::core::DebugRouterCore::GetInstance().EnableDebugChannel();
+}
+
+void DisableDebugChannel(JNIEnv *env, jobject jcaller) {
+  debugrouter::core::DebugRouterCore::GetInstance().DisableDebugChannel();
+}
+
+jboolean IsDebugChannelEnabled(JNIEnv *env, jobject jcaller) {
+  return debugrouter::core::DebugRouterCore::GetInstance()
+      .IsDebugChannelEnabled();
+}
+
 namespace debugrouter {
 namespace android {
 

--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -4,7 +4,8 @@
 
 #include "debug_router/native/core/debug_router_core.h"
 
-#include <mutex>
+#include <chrono>
+#include <thread>
 
 #include "debug_router/native/base/no_destructor.h"
 #include "debug_router/native/core/debug_router_config.h"
@@ -24,6 +25,7 @@
 namespace debugrouter {
 
 namespace core {
+
 class MessageHandlerCore : public processor::MessageHandler {
  public:
   MessageHandlerCore() {}
@@ -332,31 +334,16 @@ int32_t DebugRouterCore::GetUSBPort() {
 
 void DebugRouterCore::Pull(int32_t session_id_) {
   LOGI("pull session: " << session_id_);
-  bool stop_server = false;
+  bool removed_enabled_session = false;
   if (!enable_all_sessions_.load(std::memory_order_relaxed)) {
-    {
-      std::unique_lock lock(enabled_sessions_mutex_);
-      if (enabled_session_ids_.erase(session_id_) > 0) {
-        if (enabled_session_ids_.empty()) {
-          stop_server = true;
-        }
-      }
-    }
-    if (stop_server) {
-      thread::DebugRouterExecutor::GetInstance().Post([this]() {
-        bool should_stop = false;
-        if (!enable_all_sessions_.load(std::memory_order_relaxed)) {
-          std::unique_lock lock(enabled_sessions_mutex_);
-          should_stop = enabled_session_ids_.empty();
-        }
-        if (should_stop &&
-            !enable_all_sessions_.load(std::memory_order_relaxed)) {
-          for (size_t i = 0; i < kTransceiverCount; ++i) {
-            message_transceivers_[i]->StopServer();
-          }
-        }
-      });
-    }
+    std::unique_lock lock(enabled_sessions_mutex_);
+    removed_enabled_session = enabled_session_ids_.erase(session_id_) > 0;
+  }
+  // Server availability only depends on debug channel / enable-all /
+  // enabled-session ids. Pull() only needs to refresh the server state when it
+  // actually removes an enabled session from that decision set.
+  if (removed_enabled_session) {
+    UpdateServerState();
   }
   {
     std::unique_lock lock(slots_mutex_);
@@ -812,18 +799,60 @@ std::string DebugRouterCore::GetConnectionStateMsg(ConnectionState state) {
   }
 }
 
+bool DebugRouterCore::ShouldServerRun() {
+  if (enable_all_sessions_.load(std::memory_order_relaxed) ||
+      debug_channel_enabled_.load(std::memory_order_relaxed)) {
+    return true;
+  }
+  std::shared_lock lock(enabled_sessions_mutex_);
+  return !enabled_session_ids_.empty();
+}
+
+void DebugRouterCore::UpdateServerState() {
+  server_state_update_dirty_.store(true, std::memory_order_relaxed);
+  if (server_state_update_scheduled_.exchange(true,
+                                              std::memory_order_relaxed)) {
+    return;
+  }
+  thread::DebugRouterExecutor::GetInstance().Post(
+      [this]() {
+        for (;;) {
+          server_state_update_dirty_.store(false, std::memory_order_relaxed);
+          const bool should_run = ShouldServerRun();
+          const bool was_running =
+              server_running_.exchange(should_run, std::memory_order_relaxed);
+          if (was_running != should_run) {
+            for (size_t i = 0; i < kTransceiverCount; ++i) {
+              if (should_run) {
+                message_transceivers_[i]->StartServer();
+              } else {
+                message_transceivers_[i]->StopServer();
+              }
+            }
+          }
+
+          if (!server_state_update_dirty_.load(std::memory_order_relaxed)) {
+            server_state_update_scheduled_.store(false,
+                                                 std::memory_order_relaxed);
+            if (!server_state_update_dirty_.load(std::memory_order_relaxed)) {
+              break;
+            }
+            if (server_state_update_scheduled_.exchange(
+                    true, std::memory_order_relaxed)) {
+              break;
+            }
+          }
+        }
+      },
+      /*run_now=*/false);
+}
+
 void DebugRouterCore::EnableAllSessions() {
   if (enable_all_sessions_.exchange(true, std::memory_order_relaxed)) {
     return;
   }
   LOGI("enableAllSessions");
-  thread::DebugRouterExecutor::GetInstance().Post([this]() {
-    if (enable_all_sessions_.load(std::memory_order_relaxed)) {
-      for (size_t i = 0; i < kTransceiverCount; ++i) {
-        message_transceivers_[i]->StartServer();
-      }
-    }
-  });
+  UpdateServerState();
 }
 
 void DebugRouterCore::EnableSingleSession(int32_t session_id) {
@@ -831,23 +860,19 @@ void DebugRouterCore::EnableSingleSession(int32_t session_id) {
   if (enable_all_sessions_.load(std::memory_order_relaxed)) {
     return;
   }
+  if (session_id <= 0) {
+    LOGW("enableSingleSession ignored invalid session id: " << session_id);
+    return;
+  }
   LOGI("enableSingleSession: " << session_id);
+  bool inserted = false;
   {
     std::unique_lock lock(enabled_sessions_mutex_);
-    enabled_session_ids_.insert(session_id);
+    inserted = enabled_session_ids_.insert(session_id).second;
   }
-  thread::DebugRouterExecutor::GetInstance().Post([this, session_id]() {
-    bool should_start = false;
-    if (!enable_all_sessions_.load(std::memory_order_relaxed)) {
-      std::shared_lock lock(enabled_sessions_mutex_);
-      should_start = (enabled_session_ids_.count(session_id) > 0);
-    }
-    if (should_start) {
-      for (size_t i = 0; i < kTransceiverCount; ++i) {
-        message_transceivers_[i]->StartServer();
-      }
-    }
-  });
+  if (inserted) {
+    UpdateServerState();
+  }
 }
 
 bool DebugRouterCore::isActiveSession(int32_t session_id) {
@@ -864,6 +889,26 @@ bool DebugRouterCore::isActiveSession(int32_t session_id) {
 
 bool DebugRouterCore::isEnableAllSessions() {
   return enable_all_sessions_.load(std::memory_order_relaxed);
+}
+
+void DebugRouterCore::EnableDebugChannel() {
+  if (debug_channel_enabled_.exchange(true, std::memory_order_relaxed)) {
+    return;
+  }
+  LOGI("EnableDebugChannel");
+  UpdateServerState();
+}
+
+void DebugRouterCore::DisableDebugChannel() {
+  if (!debug_channel_enabled_.exchange(false, std::memory_order_relaxed)) {
+    return;
+  }
+  LOGI("DisableDebugChannel");
+  UpdateServerState();
+}
+
+bool DebugRouterCore::IsDebugChannelEnabled() {
+  return debug_channel_enabled_.load(std::memory_order_relaxed);
 }
 
 }  // namespace core

--- a/debug_router/native/core/debug_router_core.h
+++ b/debug_router/native/core/debug_router_core.h
@@ -138,8 +138,13 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   // these two methods are conflictive, only one of them can be enabled
   void EnableAllSessions();
   // for online debug, could only debug needed sessions, work with
-  // enabled_session_ids_
+  // enabled_session_ids_. session_id must be > 0.
   void EnableSingleSession(int32_t session_id);
+  // Debug channel only controls whether the server should stay available.
+  // It does not bypass session filtering or alter message routing semantics.
+  void EnableDebugChannel();
+  void DisableDebugChannel();
+  bool IsDebugChannelEnabled();
 
   bool isActiveSession(int32_t session_id);
   bool isEnableAllSessions();
@@ -171,6 +176,8 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   std::unordered_map<int, DebugRouterSessionHandler *> session_handler_map_;
 
  private:
+  bool ShouldServerRun();
+  void UpdateServerState();
   void Reconnect();
   void Connect(const std::string &url, const std::string &room,
                bool is_reconnect);
@@ -190,8 +197,19 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   std::atomic<int32_t> usb_port_;
   std::atomic<int> handler_count_;
   std::atomic<WebSocketConnectType> is_first_connect_;
+  // Caches the last server state requested by UpdateServerState().
+  std::atomic<bool> server_running_{false};
+  // Ensures UpdateServerState() has at most one executor task in flight.
+  // Repeated callers only flip dirty and let that single task absorb the
+  // merged state change instead of enqueueing more StartServer/StopServer work.
+  std::atomic<bool> server_state_update_scheduled_{false};
+  // Records that another UpdateServerState() request arrived while the current
+  // task was running, so the task must re-check ShouldServerRun() once more
+  // before it exits and apply only the latest merged server state.
+  std::atomic<bool> server_state_update_dirty_{false};
 
   std::atomic<bool> enable_all_sessions_{false};
+  std::atomic<bool> debug_channel_enabled_{false};
   std::unordered_set<int32_t> enabled_session_ids_;
   std::shared_mutex enabled_sessions_mutex_;
 };

--- a/debug_router/native/harmony/debug_router_harmony.cc
+++ b/debug_router/native/harmony/debug_router_harmony.cc
@@ -68,7 +68,13 @@ napi_value DebugRouterHarmony::Init(napi_env env, napi_value exports) {
       {"enableAllSessions", 0, DebugRouterHarmony::EnableAllSessions, 0, 0, 0,
        napi_static, 0},
       {"enableSingleSession", 0, DebugRouterHarmony::EnableSingleSession, 0, 0,
-       0, napi_static, 0}};
+       0, napi_static, 0},
+      {"enableDebugChannel", 0, DebugRouterHarmony::EnableDebugChannel, 0, 0, 0,
+       napi_static, 0},
+      {"disableDebugChannel", 0, DebugRouterHarmony::DisableDebugChannel, 0, 0,
+       0, napi_static, 0},
+      {"isDebugChannelEnabled", 0, DebugRouterHarmony::IsDebugChannelEnabled, 0,
+       0, 0, napi_static, 0}};
   constexpr size_t size = std::size(properties);
 
   napi_value cons;
@@ -395,6 +401,27 @@ napi_value DebugRouterHarmony::EnableSingleSession(napi_env env,
   napi_get_value_int32(env, argv[0], &session_id);
   core::DebugRouterCore::GetInstance().EnableSingleSession(session_id);
   return nullptr;
+}
+
+napi_value DebugRouterHarmony::EnableDebugChannel(napi_env env,
+                                                  napi_callback_info info) {
+  core::DebugRouterCore::GetInstance().EnableDebugChannel();
+  return nullptr;
+}
+
+napi_value DebugRouterHarmony::DisableDebugChannel(napi_env env,
+                                                   napi_callback_info info) {
+  core::DebugRouterCore::GetInstance().DisableDebugChannel();
+  return nullptr;
+}
+
+napi_value DebugRouterHarmony::IsDebugChannelEnabled(napi_env env,
+                                                     napi_callback_info info) {
+  napi_value result;
+  napi_get_boolean(env,
+                   core::DebugRouterCore::GetInstance().IsDebugChannelEnabled(),
+                   &result);
+  return result;
 }
 
 }  // namespace harmony

--- a/debug_router/native/harmony/debug_router_harmony.h
+++ b/debug_router/native/harmony/debug_router_harmony.h
@@ -83,6 +83,10 @@ class DebugRouterHarmony {
 
   static napi_value EnableAllSessions(napi_env env, napi_callback_info info);
   static napi_value EnableSingleSession(napi_env env, napi_callback_info info);
+  static napi_value EnableDebugChannel(napi_env env, napi_callback_info info);
+  static napi_value DisableDebugChannel(napi_env env, napi_callback_info info);
+  static napi_value IsDebugChannelEnabled(napi_env env,
+                                          napi_callback_info info);
 
   static std::map<napi_value, int, NapiValueCompare> global_handlers_map_;
   static std::map<napi_value, int, NapiValueCompare> session_handlers_map_;


### PR DESCRIPTION
Expose debugChannel enable/disable/isEnabled APIs across Android/iOS/Harmony and C++ common wrapper.

Refactor DebugRouterCore to centralize server availability decisions:
- Introduce ShouldServerRun() based on enableAllSessions/debugChannel/enabled sessions
- Replace scattered StartServer/StopServer posts with UpdateServerState() that merges concurrent requests (dirty/scheduled) and posts asynchronously (run_now=false) to avoid executor re-entrancy and server state thrashing

Also validate EnableSingleSession input (ignore session_id <= 0).

Behavior:
- Keep server available when debugChannel is enabled, even with no enabled sessions
- Stop server when debugChannel is off and no enabled sessions (enable_all_sessions=false)

doc: https://github.com/lynx-family/debug-router/issues/143