### PR TITLE
[BugFix]Guard repeated UsbClient stop and executor shutdown

### DIFF
--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -432,7 +432,8 @@ void UsbClient::StartWriter() {
 
 void UsbClient::DisconnectInternal() {
   LOGI("UsbClient: DisconnectInternal.");
-  // Set stopping flag to true
+  // DisconnectInternal only handles transport/read-loop shutdown. Stop()
+  // idempotence is guarded by stop_started_.
   stopping_.store(true, std::memory_order_relaxed);
   incoming_message_queue_.put(std::move(kMessageQuit));
   outgoing_message_queue_.put(std::move(kMessageQuit));
@@ -454,6 +455,14 @@ bool UsbClient::Send(const std::string &message) {
 
 void UsbClient::Stop() {
   LOGI("UsbClient: Stop.");
+  bool expected = false;
+  if (!stop_started_.compare_exchange_strong(expected, true,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire)) {
+    LOGI("UsbClient: Stop already in progress or completed.");
+    return;
+  }
+
   auto start_time = std::chrono::steady_clock::now();
 
   LOGI("UsbClient: Stop - begin DisconnectInternal");

--- a/debug_router/native/socket/usb_client.h
+++ b/debug_router/native/socket/usb_client.h
@@ -39,6 +39,8 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
 
  private:
   void StartInternal(const std::shared_ptr<UsbClientListener> &listener);
+  // Marks the client as stopping before closing the socket so read/write loops
+  // can exit even if DisconnectInternal() is called outside Stop() later.
   void DisconnectInternal();
   void SendInternal(const std::string &message);
 
@@ -98,7 +100,10 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   // mutex for close socket_fd_
   std::mutex mutex_;
   std::atomic<bool> is_connected_ = {false};
+  // Signals read/write loops to exit promptly.
   std::atomic<bool> stopping_ = {false};
+  // Guards the full Stop() sequence so shutdown executes only once.
+  std::atomic<bool> stop_started_ = {false};
 };
 
 }  // namespace socket_server

--- a/debug_router/native/socket/work_thread_executor.cc
+++ b/debug_router/native/socket/work_thread_executor.cc
@@ -34,16 +34,19 @@ void WorkThreadExecutor::submit(std::function<void()> task) {
 }
 
 void WorkThreadExecutor::shutdown() {
-  std::shared_ptr<std::thread> worker_ptr;
+  bool expected = false;
+  if (!is_shut_down.compare_exchange_strong(expected, true,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
+    return;
+  }
+
+  std::unique_ptr<std::thread> worker_ptr;
   {
     std::lock_guard<std::mutex> lock(task_mtx);
-    if (is_shut_down) {
-      return;
-    }
-    is_shut_down = true;
     std::queue<std::function<void()>> empty;
     tasks.swap(empty);
-    worker_ptr = std::move(worker);  // take ownership of worker
+    worker_ptr = std::move(worker);
   }
   cond.notify_all();
 


### PR DESCRIPTION
- Make UsbClient::Stop() execute only once with atomic CAS.
- Use atomic CAS in WorkThreadExecutor::shutdown() so only one thread enters the shutdown path.
- Prevent repeated shutdown from racing on task_mtx/worker during disconnect, error callback, and destructor paths.