### PR TITLE
[BugFix] Prevent SIGPIPE when sending socket data

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -5,18 +5,24 @@
 #ifndef DEBUGROUTER_NATIVE_BASE_SOCKET_UTIL_H_
 #define DEBUGROUTER_NATIVE_BASE_SOCKET_UTIL_H_
 
+#include <cstddef>
+
 #if defined(_WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #define CLOSESOCKET closesocket
 typedef SOCKET SocketType;
+typedef int SocketSendResult;
 #else
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <cerrno>
 #define CLOSESOCKET close
 typedef int SocketType;
+typedef ssize_t SocketSendResult;
 #endif
 #include <mutex>
 
@@ -25,6 +31,29 @@ typedef int SocketType;
 
 namespace debugrouter {
 namespace base {
+
+inline void SetNoSigPipe(SocketType sock) {
+#if !defined(_WIN32) && defined(SO_NOSIGPIPE)
+  int value = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &value, sizeof(value)) == -1) {
+    LOGE("Set SO_NOSIGPIPE failed: " << errno);
+  }
+#else
+  (void)sock;
+#endif
+}
+
+inline SocketSendResult SendNoSigPipe(SocketType sock, const void* buffer,
+                                      size_t length) {
+#if defined(_WIN32)
+  return send(sock, static_cast<const char*>(buffer), static_cast<int>(length),
+              0);
+#elif defined(MSG_NOSIGNAL)
+  return send(sock, buffer, length, MSG_NOSIGNAL);
+#else
+  return send(sock, buffer, length, 0);
+#endif
+}
 
 class SocketGuard {
  public:
@@ -42,7 +71,11 @@ class SocketGuard {
     sock_ = socket_server::kInvalidSocket;
   }
 
-  explicit SocketGuard(SocketType sock) : sock_(sock) {}
+  explicit SocketGuard(SocketType sock) : sock_(sock) {
+    if (sock_ != socket_server::kInvalidSocket) {
+      SetNoSigPipe(sock_);
+    }
+  }
 
   ~SocketGuard() {
     LOGI("SocketGuard destruct.");

--- a/debug_router/native/net/websocket_task.cc
+++ b/debug_router/native/net/websocket_task.cc
@@ -118,12 +118,12 @@ void WebSocketTask::SendInternal(const std::string &data) {
   } else {
     LOGI("WebSocketTask: [TX]: " << buf);
   }
-  if (send(socket_guard_->Get(), (char *)prefix, prefix_len, 0) == -1) {
+  if (base::SendNoSigPipe(socket_guard_->Get(), prefix, prefix_len) == -1) {
     LOGI("send prefix_len error.");
     onFailure("Send prefix_len error.", GetErrorMessage());
     return;
   }
-  if (send(socket_guard_->Get(), buf, payloadLen, 0) == -1) {
+  if (base::SendNoSigPipe(socket_guard_->Get(), buf, payloadLen) == -1) {
     LOGI("send buf error.");
     onFailure("Send buf error.", GetErrorMessage());
     return;
@@ -292,7 +292,7 @@ bool WebSocketTask::do_connect() {
            "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n"
            "Sec-WebSocket-Version: 13\r\n\r\n",
            path, host, port);
-  if (send(socket_guard_->Get(), buf, strlen(buf), 0) == -1) {
+  if (base::SendNoSigPipe(socket_guard_->Get(), buf, strlen(buf)) == -1) {
     LOGE("send http upgrade error: " << GetErrorMessage());
     onFailure("Websocket Task: socket send failed.", GetErrorMessage());
     return false;

--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -403,8 +403,8 @@ void UsbClient::WriteMessage() {
       }
       std::string result_message;
       WrapHeader(message, result_message);
-      if (send(socket_guard_.Get(), result_message.c_str(),
-               result_message.size(), 0) == -1) {
+      if (base::SendNoSigPipe(socket_guard_.Get(), result_message.c_str(),
+                              result_message.size()) == -1) {
         LOGE("send error: " << GetErrorMessage() << " message:" << message);
         if (listener_) {
           listener_->OnError(shared_from_this(), GetErrorMessage(),

--- a/debug_router/native/test/socket_util_unittest.cc
+++ b/debug_router/native/test/socket_util_unittest.cc
@@ -4,8 +4,16 @@
 
 #include <cstdlib>
 
+#include "debug_router/native/base/socket_guard.h"
 #include "debug_router/native/core/util.h"
 #include "gtest/gtest.h"
+
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#endif
 
 TEST(SocketUtilTestSuite, TestCharToUInt32) {
   EXPECT_EQ(debugrouter::util::CharToUInt32(0xF0), (uint32_t)240);
@@ -60,3 +68,21 @@ TEST(SocketUtilTestSuite, TestCheckHeader) {
   EXPECT_EQ(true, debugrouter::util::CheckHeaderThreeBytes(header));
   EXPECT_EQ(true, debugrouter::util::CheckHeaderFourthByte(header, 27));
 }
+
+#ifndef _WIN32
+TEST(SocketUtilTestSuite, SendNoSigPipeFailsWithoutTerminatingOnClosedPeer) {
+  int sockets[2] = {-1, -1};
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+
+  debugrouter::base::SocketGuard writer(sockets[0]);
+  ASSERT_EQ(close(sockets[1]), 0);
+
+  const char message[] = "x";
+  errno = 0;
+  auto result =
+      debugrouter::base::SendNoSigPipe(writer.Get(), message, sizeof(message));
+
+  EXPECT_EQ(result, -1);
+  EXPECT_EQ(errno, EPIPE);
+}
+#endif


### PR DESCRIPTION
- Add platform-specific send handling that uses MSG_NOSIGNAL on Linux and SO_NOSIGPIPE where available.
- Route WebSocket and USB socket writes through the wrapper so closed peers report send failures instead of terminating the process.
- Add a non-Windows unit test for sending to a closed socketpair.

TEST: git diff --check