### PR TITLE
[BugFix] Validate USB frames before promoting clients

### DIFF
--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -91,14 +91,6 @@ void UsbClient::StartInternal(
   StartWriter();
 }
 
-bool UsbClient::ReadAndCheckMessageHeader(char *header) {
-  if (!Read(header, kFrameHeaderLen)) {
-    LOGE("read header data error.");
-    return false;
-  }
-  return util::CheckHeaderThreeBytes(header);
-}
-
 /**
  *  The DebugRouter message structure is:
  *
@@ -127,51 +119,62 @@ bool UsbClient::ReadAndCheckMessageHeader(char *header) {
  *  checkMessageHeader will check header's value.
  */
 
-bool UsbClient::Read(char *buffer, uint32_t read_size) {
+UsbClient::ReadOutcome UsbClient::Read(char *buffer, uint32_t read_size) {
   int64_t start = 0;
   while (start < read_size) {
     int64_t read_data_len =
         recv(socket_guard_.Get(), buffer + start, read_size - start, 0);
-    if (read_data_len <= 0) {
+    if (read_data_len == 0) {
+      if (stopping_.load(std::memory_order_relaxed)) {
+        return {ReadResult::kStopped, 0};
+      }
+      return {start == 0 ? ReadResult::kEof : ReadResult::kTruncated, 0};
+    }
+    if (read_data_len < 0) {
+      if (stopping_.load(std::memory_order_relaxed)) {
+        return {ReadResult::kStopped, 0};
+      }
       // Check if it's a timeout error
 #ifdef _WIN32
       int error = WSAGetLastError();
       if (error == WSAEWOULDBLOCK || error == WSAETIMEDOUT) {
-        // Timeout, check if we're stopping
-        if (stopping_.load(std::memory_order_relaxed)) {
-          return false;
-        }
         // Continue to next iteration to check again
         continue;
       }
 #else
       int error = errno;
       if (error == EAGAIN || error == EWOULDBLOCK || error == ETIMEDOUT) {
-        // Timeout, check if we're stopping
-        if (stopping_.load(std::memory_order_relaxed)) {
-          return false;
-        }
         // Continue to next iteration to check again
         continue;
       }
 #endif
       LOGE("Read: read_data_len <= 0 :"
-           << "read target count:" << (read_size - start) << " read_data_len:"
-           << read_data_len << " error:" << GetErrorMessage());
-      return false;
+           << "read target count:" << (read_size - start)
+           << " read_data_len:" << read_data_len << " error:" << error);
+      return {ReadResult::kError, error};
     }
     start = start + read_data_len;
   }
-  if (start != read_size) {
-    LOGE("Read: read data count > read_size");
-    return false;
-  }
-  return true;
+  return {ReadResult::kSuccess, 0};
 }
 
 void UsbClient::ReadMessage() {
   LOGI("UsbClient: ReadMessage:" << socket_guard_.Get());
   bool isFirst = true;
+  bool has_completed_frame = false;
+  bool clean_eof = false;
+  int32_t terminal_error_code = 0;
+  auto report_read_failure = [&](const ReadOutcome &outcome,
+                                 const char *truncated_message,
+                                 const char *error_message) {
+    terminal_error_code = outcome.error_code;
+    if (outcome.result != ReadResult::kStopped && listener_) {
+      listener_->OnError(shared_from_this(), outcome.error_code,
+                         outcome.result == ReadResult::kError
+                             ? error_message
+                             : truncated_message);
+    }
+  };
   while (true) {
     // Check if we're stopping
     if (stopping_.load(std::memory_order_relaxed)) {
@@ -180,19 +183,70 @@ void UsbClient::ReadMessage() {
 
     char header[kFrameHeaderLen];
     memset(header, 0, kFrameHeaderLen);
-    if (!ReadAndCheckMessageHeader(header)) {
+    ReadOutcome header_outcome = Read(header, kFrameHeaderLen);
+    if (header_outcome.result != ReadResult::kSuccess) {
+      if (header_outcome.result == ReadResult::kEof) {
+        if (has_completed_frame) {
+          clean_eof = true;
+        } else {
+          report_read_failure(header_outcome,
+                              "peer closed before protocol frame", "");
+        }
+      } else {
+        report_read_failure(header_outcome, "truncated message header",
+                            "read message header data error");
+      }
+      break;
+    }
+    if (!util::CheckHeaderThreeBytes(header)) {
       LOGW("UsbClient: don't match DebugRouter protocol:");
       // need DebugRouterReport to report invailed client.
       for (int i = 0; i < kFrameHeaderLen; i++) {
         LOGE("header " << i << " : #" << util::CharToUInt32(header[i]) << "#");
       }
-      if (!isFirst && listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
+      if (listener_) {
+        listener_->OnError(shared_from_this(), 0,
                            "ReadAndCheckMessageHeader error: don't match "
                            "DebugRouter protocol");
       }
       break;
     }
+    char payload_size[kPayloadSizeLen];
+    ReadOutcome payload_size_outcome = Read(payload_size, kPayloadSizeLen);
+    if (payload_size_outcome.result != ReadResult::kSuccess) {
+      if (payload_size_outcome.result != ReadResult::kStopped) {
+        LOGE("read payload data error: " << payload_size_outcome.error_code);
+      }
+      report_read_failure(payload_size_outcome, "truncated payload size",
+                          "read payload size data error.");
+      break;
+    }
+
+    uint32_t payload_size_int =
+        util::DecodePayloadSize(payload_size, kPayloadSizeLen);
+
+    if (!util::CheckHeaderFourthByte(header, payload_size_int)) {
+      LOGE("CheckHeader failed: payload size mismatch.");
+      for (int i = 0; i < kFrameHeaderLen; i++) {
+        LOGE("header " << i << " : #" << util::CharToUInt32(header[i]) << "#");
+      }
+      if (listener_) {
+        listener_->OnError(shared_from_this(), 0,
+                           "message payload size mismatch");
+      }
+      break;
+    }
+    std::unique_ptr<char[]> payload(new char[payload_size_int]);
+    ReadOutcome payload_outcome = Read(payload.get(), payload_size_int);
+    if (payload_outcome.result != ReadResult::kSuccess) {
+      if (payload_outcome.result != ReadResult::kStopped) {
+        LOGE("read payload data error: " << payload_outcome.error_code);
+      }
+      report_read_failure(payload_outcome, "truncated payload",
+                          "read payload data error:");
+      break;
+    }
+    has_completed_frame = true;
     if (isFirst) {
       LOGI("UsbClient: handle first frame.");
       if (listener_) {
@@ -201,35 +255,6 @@ void UsbClient::ReadMessage() {
                           "Init Success!");
       }
       isFirst = false;
-    }
-    char payload_size[kPayloadSizeLen];
-    if (!Read(payload_size, kPayloadSizeLen)) {
-      LOGE("read payload data error: " << GetErrorMessage());
-      if (listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
-                           "read payload size data error.");
-      }
-      break;
-    }
-
-    uint32_t payload_size_int =
-        util::DecodePayloadSize(payload_size, kPayloadSizeLen);
-
-    if (!util::CheckHeaderFourthByte(header, payload_size_int)) {
-      LOGE("CheckHeader failed: Drop This Frame!");
-      for (int i = 0; i < kFrameHeaderLen; i++) {
-        LOGE("header " << i << " : #" << util::CharToUInt32(header[i]) << "#");
-      }
-      continue;
-    }
-    std::unique_ptr<char[]> payload(new char[payload_size_int]);
-    if (!Read(payload.get(), payload_size_int)) {
-      LOGE("read payload data error: " << GetErrorMessage());
-      if (listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
-                           "read payload data error:");
-      }
-      break;
     }
 
     std::string payload_str(payload.get(), payload_size_int);
@@ -266,8 +291,9 @@ void UsbClient::ReadMessage() {
     incoming_message_queue_.put(std::move(payload_str));
   }
   if (listener_ && is_connected_.exchange(false, std::memory_order_relaxed)) {
-    listener_->OnClose(shared_from_this(), GetErrorMessage(),
-                       "ReadMessage finished");
+    listener_->OnClose(
+        shared_from_this(), terminal_error_code,
+        clean_eof ? "peer closed connection" : "ReadMessage finished");
   }
   LOGI("UsbClient: ReadMessage thread exit.");
   incoming_message_queue_.put(std::move(kMessageQuit));

--- a/debug_router/native/socket/usb_client.h
+++ b/debug_router/native/socket/usb_client.h
@@ -40,6 +40,7 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
  private:
 #if defined(TESTING)
   friend class SocketServerPosixTestPeer;
+  friend class UsbClientTestPeer;
 #endif
 
   void StartInternal(const std::shared_ptr<UsbClientListener> &listener);
@@ -55,8 +56,14 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   void MessageDispatcher();
   void WriteMessage();
 
-  bool Read(char *buffer, uint32_t read_size);
-  bool ReadAndCheckMessageHeader(char *header);
+  enum class ReadResult { kSuccess, kEof, kTruncated, kStopped, kError };
+
+  struct ReadOutcome {
+    ReadResult result;
+    int32_t error_code;
+  };
+
+  ReadOutcome Read(char *buffer, uint32_t read_size);
 
   void CloseClientSocket(SocketType socket_fd_);
   /**

--- a/debug_router/native/test/BUILD.gn
+++ b/debug_router/native/test/BUILD.gn
@@ -74,6 +74,7 @@ unit_test("example_unittest") {
     "example_source_unittest.cc",
     "socket_server_posix_unittest.cc",
     "socket_util_unittest.cc",
+    "usb_client_unittest.cc",
   ]
   deps = [ ":example_testset" ]
 }

--- a/debug_router/native/test/socket_server_posix_unittest.cc
+++ b/debug_router/native/test/socket_server_posix_unittest.cc
@@ -20,8 +20,10 @@
 #include <string>
 
 #include "debug_router/native/base/socket_guard.h"
+#include "debug_router/native/core/debug_router_core.h"
 #include "debug_router/native/socket/count_down_latch.h"
 #include "debug_router/native/socket/usb_client.h"
+#include "debug_router/native/thread/debug_router_executor.h"
 #include "gtest/gtest.h"
 
 namespace debugrouter {
@@ -50,6 +52,11 @@ class SocketServerPosixTestPeer {
                                 std::function<void()> task) {
     server.clean_executor_.submit(std::move(task));
   }
+
+  static bool HasTemporaryClient(SocketServerPosix &server) {
+    std::lock_guard<std::mutex> lock(server.client_lock_);
+    return static_cast<bool>(server.temp_usb_client_);
+  }
 };
 
 namespace {
@@ -62,6 +69,22 @@ class NoopListener final : public SocketServerConnectionListener {
   void OnStatusChanged(ConnectionStatus, int32_t,
                        const std::string &) override {}
   void OnMessage(const std::string &) override {}
+};
+
+class ErrorObservedClientListener final : public ClientListener {
+ public:
+  ErrorObservedClientListener(std::shared_ptr<SocketServer> server,
+                              std::shared_ptr<std::promise<void>> observed)
+      : ClientListener(std::move(server)), observed_(std::move(observed)) {}
+
+  void OnError(std::shared_ptr<UsbClient> client, int32_t code,
+               const std::string &message) override {
+    ClientListener::OnError(std::move(client), code, message);
+    observed_->set_value();
+  }
+
+ private:
+  std::shared_ptr<std::promise<void>> observed_;
 };
 
 class StopServerOnExit {
@@ -129,6 +152,58 @@ int ConnectToPort(uint16_t port) {
   return socket_fd;
 }
 
+void SendAll(SocketType socket, const std::string &data) {
+  size_t sent = 0;
+  while (sent < data.size()) {
+    const auto result =
+        base::SendNoSigPipe(socket, data.data() + sent, data.size() - sent);
+    ASSERT_GT(result, 0);
+    sent += static_cast<size_t>(result);
+  }
+}
+
+void ExpectStartupFailureReleasesTemporaryClient(
+    const std::string &startup_bytes) {
+  static_cast<void>(core::DebugRouterCore::GetInstance());
+  auto server =
+      std::make_shared<SocketServerPosix>(std::make_shared<NoopListener>());
+  StopServerOnExit stop_server(server);
+
+  int sockets[2] = {-1, -1};
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+  base::SocketGuard peer(sockets[1]);
+  auto client = std::make_shared<UsbClient>(sockets[0]);
+  std::weak_ptr<UsbClient> client_weak = client;
+  SocketServerPosixTestPeer::SetTemporaryClient(*server, client);
+
+  auto error_observed = std::make_shared<std::promise<void>>();
+  auto error_observed_future = error_observed->get_future();
+  auto client_listener =
+      std::make_shared<ErrorObservedClientListener>(server, error_observed);
+  client->Init();
+  client->StartUp(client_listener);
+  client.reset();
+
+  SendAll(peer.Get(), startup_bytes);
+  ASSERT_EQ(shutdown(peer.Get(), SHUT_WR), 0);
+  ASSERT_EQ(error_observed_future.wait_for(2s), std::future_status::ready);
+
+  auto status_drained = std::make_shared<std::promise<void>>();
+  auto status_drained_future = status_drained->get_future();
+  thread::DebugRouterExecutor::GetInstance().Post(
+      [status_drained]() { status_drained->set_value(); });
+  ASSERT_EQ(status_drained_future.wait_for(2s), std::future_status::ready);
+
+  auto cleanup_drained = std::make_shared<std::promise<void>>();
+  auto cleanup_drained_future = cleanup_drained->get_future();
+  SocketServerPosixTestPeer::SubmitCleanupWork(
+      *server, [cleanup_drained]() { cleanup_drained->set_value(); });
+  ASSERT_EQ(cleanup_drained_future.wait_for(2s), std::future_status::ready);
+
+  EXPECT_FALSE(SocketServerPosixTestPeer::HasTemporaryClient(*server));
+  EXPECT_TRUE(client_weak.expired());
+}
+
 TEST(SocketServerPosixTestSuite,
      AcceptsNewClientBeforeSupersededClientCleanupCompletes) {
   auto listener = std::make_shared<NoopListener>();
@@ -182,6 +257,12 @@ TEST(SocketServerPosixTestSuite,
 
   EXPECT_TRUE(accepted_before_cleanup);
   EXPECT_TRUE(old_client_weak.expired());
+}
+
+TEST(SocketServerPosixTestSuite, StartupFailuresReleaseTemporaryClient) {
+  ExpectStartupFailureReleasesTemporaryClient("");
+  ExpectStartupFailureReleasesTemporaryClient(
+      std::string(kFrameHeaderLen, '\0'));
 }
 
 }  // namespace

--- a/debug_router/native/test/usb_client_unittest.cc
+++ b/debug_router/native/test/usb_client_unittest.cc
@@ -1,0 +1,328 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef _WIN32
+
+#include "debug_router/native/socket/usb_client.h"
+
+#include <sys/socket.h>
+
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "debug_router/native/base/socket_guard.h"
+#include "debug_router/native/core/util.h"
+#include "debug_router/native/socket/usb_client_listener.h"
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace socket_server {
+
+class UsbClientTestPeer {
+ public:
+  static std::pair<bool, int32_t> ReadOneByte(UsbClient& client) {
+    char byte = 0;
+    const UsbClient::ReadOutcome outcome = client.Read(&byte, 1);
+    return {outcome.result == UsbClient::ReadResult::kError,
+            outcome.error_code};
+  }
+};
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class RecordingUsbClientListener final : public UsbClientListener {
+ public:
+  void OnOpen(std::shared_ptr<UsbClient>, int32_t,
+              const std::string&) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++open_count_;
+    condition_.notify_all();
+  }
+
+  void OnClose(std::shared_ptr<UsbClient>, int32_t code,
+               const std::string& reason) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++close_count_;
+    close_code_ = code;
+    close_reason_ = reason;
+    condition_.notify_all();
+  }
+
+  void OnError(std::shared_ptr<UsbClient>, int32_t code,
+               const std::string& message) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++error_count_;
+    error_code_ = code;
+    error_message_ = message;
+    condition_.notify_all();
+  }
+
+  void OnMessage(std::shared_ptr<UsbClient>, const std::string&) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++message_count_;
+    condition_.notify_all();
+  }
+
+  bool WaitForMessage() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return condition_.wait_for(lock, 2s, [this] { return message_count_ > 0; });
+  }
+
+  bool WaitForClose() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return condition_.wait_for(lock, 2s, [this] { return close_count_ > 0; });
+  }
+
+  bool WaitForError() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return condition_.wait_for(lock, 2s, [this] { return error_count_ > 0; });
+  }
+
+  int error_count() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return error_count_;
+  }
+
+  int open_count() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return open_count_;
+  }
+
+  int error_code() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return error_code_;
+  }
+
+  int close_count() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return close_count_;
+  }
+
+  int close_code() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return close_code_;
+  }
+
+  std::string close_reason() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return close_reason_;
+  }
+
+  std::string error_message() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return error_message_;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  int close_count_ = 0;
+  int error_count_ = 0;
+  int message_count_ = 0;
+  int open_count_ = 0;
+  int close_code_ = -1;
+  int error_code_ = -1;
+  std::string close_reason_;
+  std::string error_message_;
+};
+
+class UsbClientTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets_), 0);
+    client_ = std::make_shared<UsbClient>(sockets_[0]);
+    peer_ = std::make_unique<base::SocketGuard>(sockets_[1]);
+    listener_ = std::make_shared<RecordingUsbClientListener>();
+    client_->Init();
+    client_->StartUp(listener_);
+  }
+
+  void TearDown() override {
+    peer_->Reset();
+    client_->Stop();
+  }
+
+  void EstablishConnection() {
+    SendAll(BuildFrame("{}"));
+    ASSERT_TRUE(listener_->WaitForMessage());
+  }
+
+  void SendThenFinish(const std::string& data) {
+    SendAll(data);
+    ASSERT_EQ(shutdown(peer_->Get(), SHUT_WR), 0);
+  }
+
+  static std::string BuildFrame(const std::string& payload) {
+    std::string frame(kFrameHeaderLen + kPayloadSizeLen + payload.size(), '\0');
+    char encoded[4];
+    util::IntToCharArray(kFrameProtocolVersion, encoded);
+    memcpy(frame.data(), encoded, 4);
+    util::IntToCharArray(kPTFrameTypeTextMessage, encoded);
+    memcpy(frame.data() + 4, encoded, 4);
+    util::IntToCharArray(kFrameDefaultTag, encoded);
+    memcpy(frame.data() + 8, encoded, 4);
+    util::IntToCharArray(
+        static_cast<uint32_t>(kPayloadSizeLen + payload.size()), encoded);
+    memcpy(frame.data() + 12, encoded, 4);
+    util::IntToCharArray(static_cast<uint32_t>(payload.size()), encoded);
+    memcpy(frame.data() + kFrameHeaderLen, encoded, 4);
+    memcpy(frame.data() + kFrameHeaderLen + kPayloadSizeLen, payload.data(),
+           payload.size());
+    return frame;
+  }
+
+  void SendAll(const std::string& data) {
+    size_t sent = 0;
+    while (sent < data.size()) {
+      const auto result = base::SendNoSigPipe(peer_->Get(), data.data() + sent,
+                                              data.size() - sent);
+      ASSERT_GT(result, 0);
+      sent += static_cast<size_t>(result);
+    }
+  }
+
+  int sockets_[2] = {-1, -1};
+  std::shared_ptr<UsbClient> client_;
+  std::unique_ptr<base::SocketGuard> peer_;
+  std::shared_ptr<RecordingUsbClientListener> listener_;
+};
+
+TEST_F(UsbClientTest, EofAtNextFrameBoundaryIsCleanClose) {
+  EstablishConnection();
+
+  ASSERT_EQ(shutdown(peer_->Get(), SHUT_WR), 0);
+
+  ASSERT_TRUE(listener_->WaitForClose());
+  EXPECT_EQ(listener_->error_count(), 0);
+  EXPECT_EQ(listener_->close_code(), 0);
+  EXPECT_EQ(listener_->close_reason(), "peer closed connection");
+}
+
+TEST_F(UsbClientTest, EofBeforeFirstFrameIsConnectionError) {
+  ASSERT_EQ(shutdown(peer_->Get(), SHUT_WR), 0);
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(listener_->error_message(), "peer closed before protocol frame");
+  EXPECT_EQ(listener_->close_count(), 0);
+}
+
+TEST_F(UsbClientTest, InvalidHeaderBeforeFirstFrameIsConnectionError) {
+  std::string frame = BuildFrame("first");
+  frame[0] = static_cast<char>(0x7f);
+
+  SendThenFinish(frame);
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(
+      listener_->error_message(),
+      "ReadAndCheckMessageHeader error: don't match DebugRouter protocol");
+  EXPECT_EQ(listener_->close_count(), 0);
+}
+
+TEST_F(UsbClientTest, PartialHeaderEofIsTruncationError) {
+  EstablishConnection();
+  const std::string next_frame = BuildFrame("next");
+
+  SendThenFinish(next_frame.substr(0, 7));
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(listener_->error_message(), "truncated message header");
+}
+
+TEST_F(UsbClientTest, CompleteInvalidHeaderIsProtocolMismatchError) {
+  EstablishConnection();
+  std::string next_frame = BuildFrame("next");
+  next_frame[0] = static_cast<char>(0x7f);
+
+  SendThenFinish(next_frame);
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(
+      listener_->error_message(),
+      "ReadAndCheckMessageHeader error: don't match DebugRouter protocol");
+}
+
+TEST_F(UsbClientTest, PartialPayloadSizeEofIsTruncationError) {
+  EstablishConnection();
+  const std::string next_frame = BuildFrame("next");
+
+  SendThenFinish(next_frame.substr(0, kFrameHeaderLen + 2));
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(listener_->error_message(), "truncated payload size");
+}
+
+TEST_F(UsbClientTest, PartialPayloadEofIsTruncationError) {
+  EstablishConnection();
+  const std::string next_frame = BuildFrame("next");
+
+  SendThenFinish(next_frame.substr(0, kFrameHeaderLen + kPayloadSizeLen + 2));
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(listener_->error_message(), "truncated payload");
+}
+
+TEST_F(UsbClientTest, PartialFirstPayloadDoesNotOpenConnection) {
+  const std::string frame = BuildFrame("first");
+
+  SendThenFinish(frame.substr(0, kFrameHeaderLen + kPayloadSizeLen + 2));
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_count(), 1);
+  EXPECT_EQ(listener_->open_count(), 0);
+  EXPECT_EQ(listener_->error_message(), "truncated payload");
+}
+
+TEST_F(UsbClientTest, PayloadSizeMismatchIsProtocolError) {
+  std::string frame = BuildFrame("next");
+  char encoded[4];
+  util::IntToCharArray(5, encoded);
+  memcpy(frame.data() + kFrameHeaderLen, encoded, sizeof(encoded));
+
+  SendThenFinish(frame.substr(0, kFrameHeaderLen + kPayloadSizeLen));
+
+  ASSERT_TRUE(listener_->WaitForError());
+  EXPECT_EQ(listener_->error_count(), 1);
+  EXPECT_EQ(listener_->open_count(), 0);
+  EXPECT_EQ(listener_->error_code(), 0);
+  EXPECT_EQ(listener_->error_message(), "message payload size mismatch");
+}
+
+TEST_F(UsbClientTest, LocalStopDoesNotReportRemoteReadError) {
+  EstablishConnection();
+
+  client_->Stop();
+
+  EXPECT_EQ(listener_->error_count(), 0);
+}
+
+TEST(UsbClientReadTest, CapturesSocketErrorAtRecvFailure) {
+  UsbClient client(kInvalidSocket);
+
+  const auto [is_error, error_code] = UsbClientTestPeer::ReadOneByte(client);
+  errno = EAGAIN;
+
+  EXPECT_TRUE(is_error);
+  EXPECT_EQ(error_code, EBADF);
+}
+
+}  // namespace
+}  // namespace socket_server
+}  // namespace debugrouter
+
+#endif  // _WIN32


### PR DESCRIPTION
## Summary

- Distinguish clean USB EOF from truncated frames and real socket errors.
- Do not promote a newly accepted client until its first complete DebugRouter frame has been validated.
- Reject invalid headers and inconsistent payload sizes instead of attempting to resynchronize inside a corrupted frame.
- Preserve local Stop semantics without reporting a false remote read error.

This prevents a short or malformed replacement connection from displacing a healthy USB generation. It does not retry or replay in-flight requests.

## Test

- Clean native build of example_unittest
- example_unittest: 34/34
- JNI harness
- clang-format --dry-run --Werror
- git diff --check
