### PR TITLE
[BugFix] Harden socket server transport cleanup and dedupe failure callbacks

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -62,6 +62,20 @@ class SocketGuard {
     return sock_;
   }
 
+  void ShutdownAndReset() {
+    LOGI("SocketGuard shutdown and reset.");
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (sock_ != socket_server::kInvalidSocket) {
+#ifdef _WIN32
+      shutdown(sock_, SD_BOTH);
+#else
+      shutdown(sock_, SHUT_RDWR);
+#endif
+      CLOSESOCKET(sock_);
+    }
+    sock_ = socket_server::kInvalidSocket;
+  }
+
   void Reset() {
     LOGI("SocketGuard reset.");
     std::lock_guard<std::mutex> lock(mutex_);

--- a/debug_router/native/net/websocket_task.cc
+++ b/debug_router/native/net/websocket_task.cc
@@ -77,7 +77,20 @@ WebSocketTask::WebSocketTask(
 
 WebSocketTask::~WebSocketTask() { shutdown(); }
 
+void WebSocketTask::BeginTransportShutdown() {
+  stopping_.store(true, std::memory_order_relaxed);
+  if (socket_guard_) {
+    socket_guard_->ShutdownAndReset();
+  }
+}
+
 void WebSocketTask::SendInternal(const std::string &data) {
+  if (stopping_.load(std::memory_order_relaxed) ||
+      (socket_guard_ &&
+       socket_guard_->Get() == socket_server::kInvalidSocket)) {
+    LOGI("WebSocketTask::SendInternal: dropping send for closed connection.");
+    return;
+  }
   const char *buf = data.data();
   size_t payloadLen = data.size();
   uint8_t prefix[14];
@@ -135,6 +148,10 @@ void WebSocketTask::Start() {
 }
 
 void WebSocketTask::StartInternal() {
+  stopping_.store(false, std::memory_order_relaxed);
+  failure_reported_.store(false, std::memory_order_relaxed);
+  closed_reported_.store(false, std::memory_order_relaxed);
+  is_connected_.store(false, std::memory_order_relaxed);
   if (!do_connect()) {
     LOGE("Websocket connect failed.");
     return;
@@ -148,16 +165,16 @@ void WebSocketTask::StartInternal() {
     onMessage(msg);
   }
 
-  if (is_connected_.load(std::memory_order_relaxed)) {
-    onClose();
-  }
+  // StartInternal resets closed_reported_ before every connect attempt, so the
+  // unconditional onClose() here is safe: pre-open failures still stay silent
+  // because NotifyClosedOnce() also checks is_connected_.
+  onClose();
 }
 
 void WebSocketTask::Stop() {
-  socket_guard_->Reset();
-  if (is_connected_.load(std::memory_order_relaxed)) {
-    onClose();
-  }
+  LOGI("WebSocketTask::Stop");
+  BeginTransportShutdown();
+  NotifyClosedOnce();
   shutdown();
 }
 
@@ -395,6 +412,10 @@ bool WebSocketTask::do_read(std::string &msg) {
 }
 
 void WebSocketTask::onOpen() {
+  LOGI("WebSocketTask::onOpen");
+  if (stopping_.load(std::memory_order_relaxed)) {
+    return;
+  }
   is_connected_.store(true, std::memory_order_relaxed);
   auto transceiver = transceiver_.lock();
   if (transceiver) {
@@ -404,22 +425,48 @@ void WebSocketTask::onOpen() {
 
 void WebSocketTask::onFailure(const std::string &error_message,
                               int error_code) {
+  LOGI("WebSocketTask::onFailure with error_code.");
+  BeginTransportShutdown();
+  NotifyFailureOnce(error_message, error_code);
+  NotifyClosedOnce();
+}
+
+void WebSocketTask::NotifyFailureOnce(const std::string &error_message,
+                                      int error_code) {
+  bool expected = false;
+  if (!failure_reported_.compare_exchange_strong(expected, true,
+                                                 std::memory_order_acq_rel,
+                                                 std::memory_order_acquire)) {
+    return;
+  }
   auto transceiver = transceiver_.lock();
   if (transceiver) {
     transceiver->delegate()->OnFailure(transceiver, error_message, error_code);
   }
 }
 
-void WebSocketTask::onClose() {
-  bool expected = true;
-  if (!is_connected_.compare_exchange_strong(expected, false,
-                                             std::memory_order_relaxed)) {
+void WebSocketTask::NotifyClosedOnce() {
+  bool expected = false;
+  // First gate ensures only one path can attempt close delivery. The
+  // subsequent is_connected_ exchange keeps the pre-open case silent, which is
+  // required for Stop/Failure-before-open races.
+  if (!closed_reported_.compare_exchange_strong(expected, true,
+                                                std::memory_order_acq_rel,
+                                                std::memory_order_acquire)) {
+    return;
+  }
+  if (!is_connected_.exchange(false, std::memory_order_relaxed)) {
     return;
   }
   auto transceiver = transceiver_.lock();
   if (transceiver) {
     transceiver->delegate()->OnClosed(transceiver);
   }
+}
+
+void WebSocketTask::onClose() {
+  LOGI("WebSocketTask::onClose with error_message.");
+  NotifyClosedOnce();
 }
 
 void WebSocketTask::onMessage(const std::string &msg) {

--- a/debug_router/native/net/websocket_task.h
+++ b/debug_router/native/net/websocket_task.h
@@ -29,12 +29,27 @@ class WebSocketTask : public base::WorkThreadExecutor {
   void Start();
   void SendInternal(const std::string &data);
 
+#ifdef TESTING
+  void SetConnectedForTest(bool connected) {
+    is_connected_.store(connected, std::memory_order_relaxed);
+  }
+
+  void NotifyFailureForTest(const std::string &error_message, int error_code) {
+    onFailure(error_message, error_code);
+  }
+
+  void NotifyCloseForTest() { onClose(); }
+#endif
+
  private:
   void StartInternal();
+  void BeginTransportShutdown();
 
   bool do_connect();
   bool do_read(std::string &msg);
 
+  void NotifyFailureOnce(const std::string &error_message, int error_code);
+  void NotifyClosedOnce();
   void onOpen();
   void onFailure(const std::string &error_message, int error_code);
   void onClose();
@@ -45,6 +60,9 @@ class WebSocketTask : public base::WorkThreadExecutor {
   std::string url_;
   std::unique_ptr<base::SocketGuard> socket_guard_;
   std::atomic<bool> is_connected_ = {false};
+  std::atomic<bool> stopping_ = {false};
+  std::atomic<bool> failure_reported_ = {false};
+  std::atomic<bool> closed_reported_ = {false};
 };
 
 }  // namespace net

--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -20,6 +20,8 @@ SocketServerPosix::SocketServerPosix(
     const std::shared_ptr<SocketServerConnectionListener> &listener)
     : SocketServer(listener) {}
 
+SocketServerPosix::~SocketServerPosix() { Close(); }
+
 int32_t SocketServerPosix::InitSocket() {
   LOGI("SocketServerPosix::InitSocket");
 
@@ -99,8 +101,8 @@ void SocketServerPosix::Start() {
   }
   LOGI("accept usbclient socket:" << accept_socket_fd);
   std::shared_ptr<UsbClient> old_temp_client;
-  std::shared_ptr<UsbClient> new_temp_client =
-      std::make_shared<UsbClient>(accept_socket_fd);
+  LOGI("create a new usb client.");
+  auto new_temp_client = std::make_shared<UsbClient>(accept_socket_fd);
   {
     std::lock_guard<std::mutex> lock(client_lock_);
     old_temp_client = temp_usb_client_;

--- a/debug_router/native/socket/posix/socket_server_posix.h
+++ b/debug_router/native/socket/posix/socket_server_posix.h
@@ -14,6 +14,7 @@ class SocketServerPosix : public SocketServer {
  public:
   explicit SocketServerPosix(
       const std::shared_ptr<SocketServerConnectionListener> &listener);
+  ~SocketServerPosix() override;
 
  private:
 #if defined(TESTING)

--- a/debug_router/native/socket/socket_server_api.cc
+++ b/debug_router/native/socket/socket_server_api.cc
@@ -276,9 +276,9 @@ void SocketServer::Close() {
   SocketType socket_fd =
       socket_fd_.exchange(kInvalidSocket, std::memory_order_acq_rel);
   LOGI("SocketServer::Close server socket_fd_:" << socket_fd);
-  if (socket_fd == kInvalidSocket) {
-    return;
-  }
+  // The atomic exchange above is the only cross-thread double-close guard we
+  // need here. Backend-specific CloseSocket() keeps the kInvalidSocket check so
+  // all close validation remains centralized in one place.
   CloseSocket(socket_fd);
 }
 
@@ -317,7 +317,6 @@ SocketServer::~SocketServer() {
   if (pending_client && pending_client != current_client) {
     pending_client->Stop();
   }
-  Close();
 }
 
 }  // namespace socket_server

--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -63,10 +63,47 @@ UsbClient::UsbClient(SocketType socket_fd) : socket_guard_(socket_fd) {
   }
 }
 
+void UsbClient::BeginTransportShutdown() {
+  stopping_.store(true, std::memory_order_relaxed);
+  connect_status_.store(USBConnectStatus::DISCONNECTED,
+                        std::memory_order_relaxed);
+  incoming_message_queue_.put(std::string(kMessageQuit));
+  outgoing_message_queue_.put(std::string(kMessageQuit));
+  socket_guard_.ShutdownAndReset();
+}
+
+void UsbClient::NotifyErrorOnce(int32_t code, const std::string &message) {
+  bool expected = false;
+  if (!failure_reported_.compare_exchange_strong(expected, true,
+                                                 std::memory_order_acq_rel,
+                                                 std::memory_order_acquire)) {
+    return;
+  }
+  if (listener_) {
+    listener_->OnError(shared_from_this(), code, message);
+  }
+}
+
+void UsbClient::NotifyCloseOnce(int32_t code, const std::string &reason) {
+  bool expected = false;
+  // First gate ensures only one path can attempt close delivery. The
+  // subsequent is_connected_ exchange keeps the pre-open case silent, which is
+  // required for Stop/Close-before-open races.
+  if (!closed_reported_.compare_exchange_strong(expected, true,
+                                                std::memory_order_acq_rel,
+                                                std::memory_order_acquire)) {
+    return;
+  }
+  if (!is_connected_.exchange(false, std::memory_order_relaxed)) {
+    return;
+  }
+  if (listener_) {
+    listener_->OnClose(shared_from_this(), code, reason);
+  }
+}
+
 void UsbClient::SetConnectStatus(USBConnectStatus status) {
-  work_thread_.submit([client_ptr = shared_from_this(), status]() {
-    client_ptr->connect_status_ = status;
-  });
+  connect_status_.store(status, std::memory_order_relaxed);
 }
 
 void UsbClient::Init() {
@@ -85,18 +122,14 @@ void UsbClient::StartUp(const std::shared_ptr<UsbClientListener> &listener) {
 void UsbClient::StartInternal(
     const std::shared_ptr<UsbClientListener> &listener) {
   stopping_.store(false, std::memory_order_relaxed);
-  connect_status_ = USBConnectStatus::CONNECTING;
+  failure_reported_.store(false, std::memory_order_relaxed);
+  closed_reported_.store(false, std::memory_order_relaxed);
+  connect_status_.store(USBConnectStatus::CONNECTING,
+                        std::memory_order_relaxed);
+  LOGI("StartInternal, listener is:" << listener.get());
   listener_ = listener;
   StartReader();
   StartWriter();
-}
-
-bool UsbClient::ReadAndCheckMessageHeader(char *header) {
-  if (!Read(header, kFrameHeaderLen)) {
-    LOGE("read header data error.");
-    return false;
-  }
-  return util::CheckHeaderThreeBytes(header);
 }
 
 /**
@@ -127,19 +160,33 @@ bool UsbClient::ReadAndCheckMessageHeader(char *header) {
  *  checkMessageHeader will check header's value.
  */
 
-bool UsbClient::Read(char *buffer, uint32_t read_size) {
+UsbClient::ReadResult UsbClient::Read(char *buffer, uint32_t read_size,
+                                      int32_t *error_code) {
+  if (error_code) {
+    *error_code = 0;
+  }
   int64_t start = 0;
   while (start < read_size) {
     int64_t read_data_len =
         recv(socket_guard_.Get(), buffer + start, read_size - start, 0);
-    if (read_data_len <= 0) {
+    if (read_data_len == 0) {
+      if (stopping_.load(std::memory_order_relaxed)) {
+        LOGI("Read: peer closed while stopping, exit read loop");
+        return ReadResult::kStopped;
+      }
+      LOGI("Read: peer closed connection (EOF)"
+           << " read target count:" << (read_size - start));
+      return ReadResult::kClosed;
+    }
+    if (read_data_len < 0) {
       // Check if it's a timeout error
 #ifdef _WIN32
       int error = WSAGetLastError();
       if (error == WSAEWOULDBLOCK || error == WSAETIMEDOUT) {
         // Timeout, check if we're stopping
         if (stopping_.load(std::memory_order_relaxed)) {
-          return false;
+          LOGI("Read: stopping after recv timeout, exit read loop");
+          return ReadResult::kStopped;
         }
         // Continue to next iteration to check again
         continue;
@@ -149,47 +196,85 @@ bool UsbClient::Read(char *buffer, uint32_t read_size) {
       if (error == EAGAIN || error == EWOULDBLOCK || error == ETIMEDOUT) {
         // Timeout, check if we're stopping
         if (stopping_.load(std::memory_order_relaxed)) {
-          return false;
+          LOGI("Read: stopping after recv timeout, exit read loop");
+          return ReadResult::kStopped;
         }
         // Continue to next iteration to check again
         continue;
       }
 #endif
+      if (stopping_.load(std::memory_order_relaxed)) {
+        LOGI("Read: stopping after socket error, exit read loop");
+        return ReadResult::kStopped;
+      }
       LOGE("Read: read_data_len <= 0 :"
-           << "read target count:" << (read_size - start) << " read_data_len:"
-           << read_data_len << " error:" << GetErrorMessage());
-      return false;
+           << "read target count:" << (read_size - start)
+           << " read_data_len:" << read_data_len << " error:" << error);
+      if (error_code) {
+        *error_code = error;
+      }
+      return ReadResult::kError;
     }
     start = start + read_data_len;
   }
   if (start != read_size) {
     LOGE("Read: read data count > read_size");
-    return false;
+    return ReadResult::kError;
   }
-  return true;
+  return ReadResult::kOk;
 }
 
 void UsbClient::ReadMessage() {
   LOGI("UsbClient: ReadMessage:" << socket_guard_.Get());
   bool isFirst = true;
+  int32_t close_code = 0;
+  std::string close_reason = "ReadMessage finished";
   while (true) {
     // Check if we're stopping
     if (stopping_.load(std::memory_order_relaxed)) {
+      LOGI("UsbClient: ReadMessage: stopping, exit loop");
+      close_reason = "ReadMessage stopped";
       break;
     }
 
     char header[kFrameHeaderLen];
     memset(header, 0, kFrameHeaderLen);
-    if (!ReadAndCheckMessageHeader(header)) {
+    LOGI("UsbClient: start check message header.");
+    int32_t error_code = 0;
+    ReadResult header_result = Read(header, kFrameHeaderLen, &error_code);
+    if (header_result == ReadResult::kStopped) {
+      close_reason = "ReadMessage stopped";
+      break;
+    }
+    if (header_result == ReadResult::kClosed) {
+      LOGI("UsbClient: peer closed connection before next frame.");
+      BeginTransportShutdown();
+      close_reason = "peer closed connection (EOF)";
+      break;
+    }
+    if (header_result == ReadResult::kError) {
+      LOGE("read header data error.");
+      BeginTransportShutdown();
+      close_code = error_code;
+      close_reason = "ReadMessage finished after socket error";
+      if (!isFirst) {
+        NotifyErrorOnce(error_code, "ReadMessage header read socket error");
+      }
+      break;
+    }
+    if (!util::CheckHeaderThreeBytes(header)) {
       LOGW("UsbClient: don't match DebugRouter protocol:");
       // need DebugRouterReport to report invailed client.
       for (int i = 0; i < kFrameHeaderLen; i++) {
         LOGE("header " << i << " : #" << util::CharToUInt32(header[i]) << "#");
       }
-      if (!isFirst && listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
-                           "ReadAndCheckMessageHeader error: don't match "
-                           "DebugRouter protocol");
+      BeginTransportShutdown();
+      close_code = GetErrorMessage();
+      close_reason = "ReadMessage finished after protocol mismatch";
+      if (!isFirst) {
+        NotifyErrorOnce(close_code,
+                        "ReadAndCheckMessageHeader error: don't match "
+                        "DebugRouter protocol");
       }
       break;
     }
@@ -203,12 +288,24 @@ void UsbClient::ReadMessage() {
       isFirst = false;
     }
     char payload_size[kPayloadSizeLen];
-    if (!Read(payload_size, kPayloadSizeLen)) {
-      LOGE("read payload data error: " << GetErrorMessage());
-      if (listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
-                           "read payload size data error.");
-      }
+    ReadResult payload_size_result =
+        Read(payload_size, kPayloadSizeLen, &error_code);
+    if (payload_size_result == ReadResult::kStopped) {
+      close_reason = "ReadMessage stopped";
+      break;
+    }
+    if (payload_size_result == ReadResult::kClosed) {
+      LOGI("read payload size hit EOF");
+      BeginTransportShutdown();
+      close_reason = "peer closed connection (EOF)";
+      break;
+    }
+    if (payload_size_result == ReadResult::kError) {
+      LOGE("read payload size data error: " << error_code);
+      BeginTransportShutdown();
+      close_code = error_code;
+      close_reason = "ReadMessage finished after payload-size read error";
+      NotifyErrorOnce(error_code, "read payload size data error.");
       break;
     }
 
@@ -223,12 +320,24 @@ void UsbClient::ReadMessage() {
       continue;
     }
     std::unique_ptr<char[]> payload(new char[payload_size_int]);
-    if (!Read(payload.get(), payload_size_int)) {
-      LOGE("read payload data error: " << GetErrorMessage());
-      if (listener_) {
-        listener_->OnError(shared_from_this(), GetErrorMessage(),
-                           "read payload data error:");
-      }
+    ReadResult payload_result =
+        Read(payload.get(), payload_size_int, &error_code);
+    if (payload_result == ReadResult::kStopped) {
+      close_reason = "ReadMessage stopped";
+      break;
+    }
+    if (payload_result == ReadResult::kClosed) {
+      LOGI("read payload hit EOF");
+      BeginTransportShutdown();
+      close_reason = "peer closed connection (EOF)";
+      break;
+    }
+    if (payload_result == ReadResult::kError) {
+      LOGI("read payload data error: " << error_code);
+      BeginTransportShutdown();
+      close_code = error_code;
+      close_reason = "ReadMessage finished after payload read error";
+      NotifyErrorOnce(error_code, "read payload data error:");
       break;
     }
 
@@ -265,10 +374,9 @@ void UsbClient::ReadMessage() {
 
     incoming_message_queue_.put(std::move(payload_str));
   }
-  if (listener_ && is_connected_.exchange(false, std::memory_order_relaxed)) {
-    listener_->OnClose(shared_from_this(), GetErrorMessage(),
-                       "ReadMessage finished");
-  }
+  // end read loop.
+  LOGI("UsbClient: ReadMessage finished.");
+  NotifyCloseOnce(close_code, close_reason);
   LOGI("UsbClient: ReadMessage thread exit.");
   incoming_message_queue_.put(std::move(kMessageQuit));
   outgoing_message_queue_.put(std::move(kMessageQuit));
@@ -385,18 +493,16 @@ void UsbClient::WriteMessage() {
       if (base::SendNoSigPipe(socket_guard_.Get(), result_message.c_str(),
                               result_message.size()) == -1) {
         LOGE("send error: " << GetErrorMessage() << " message:" << message);
-        if (listener_) {
-          listener_->OnError(shared_from_this(), GetErrorMessage(),
-                             "UsbClient::WriteMessage send data failed.");
-        }
+        BeginTransportShutdown();
+        NotifyErrorOnce(GetErrorMessage(),
+                        "UsbClient::WriteMessage send data failed.");
+        NotifyCloseOnce(GetErrorMessage(), "writer thread finished");
         break;
       }
     }
   }
-  if (listener_ && is_connected_.exchange(false, std::memory_order_relaxed)) {
-    listener_->OnClose(shared_from_this(), GetErrorMessage(),
-                       "writer thread finished");
-  }
+  LOGI("UsbClient: WriteMessage finished.");
+  NotifyCloseOnce(GetErrorMessage(), "writer thread finished");
   LOGI("UsbClient: WriteMessage thread exit.");
 }
 
@@ -408,13 +514,16 @@ void UsbClient::StartWriter() {
 void UsbClient::DisconnectInternal() {
   // DisconnectInternal only handles transport/read-loop shutdown. Stop()
   // idempotence is guarded by stop_started_.
-  stopping_.store(true, std::memory_order_relaxed);
-  incoming_message_queue_.put(std::move(kMessageQuit));
-  outgoing_message_queue_.put(std::move(kMessageQuit));
-  socket_guard_.Reset();
+  BeginTransportShutdown();
 }
 
 bool UsbClient::Send(const std::string &message) {
+  LOGI("UsbClient: Send.");
+  if (stopping_.load(std::memory_order_relaxed) ||
+      stop_started_.load(std::memory_order_relaxed)) {
+    LOGI("UsbClient: dropping send while stopping.");
+    return false;
+  }
   if (message.size() >
       (kMaxMessageLength - kFrameHeaderLen - kPayloadSizeLen)) {
     LOGE("current protocol only support 1UL << 32 bytes message");
@@ -444,7 +553,8 @@ void UsbClient::Stop() {
 
   incoming_message_queue_.clear();
   outgoing_message_queue_.clear();
-  connect_status_ = USBConnectStatus::DISCONNECTED;
+  connect_status_.store(USBConnectStatus::DISCONNECTED,
+                        std::memory_order_relaxed);
 
   auto end_time = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -454,8 +564,11 @@ void UsbClient::Stop() {
 }
 
 void UsbClient::SendInternal(const std::string &message) {
-  if (connect_status_ != USBConnectStatus::CONNECTED) {
-    LOGW("current usb client is not connected");
+  LOGI("UsbClient: SendInternal.");
+  if (stopping_.load(std::memory_order_relaxed) ||
+      connect_status_.load(std::memory_order_relaxed) !=
+          USBConnectStatus::CONNECTED) {
+    LOGI("current usb client is not connected:" << message);
     return;
   }
   std::string non_const_message = message;

--- a/debug_router/native/socket/usb_client.h
+++ b/debug_router/native/socket/usb_client.h
@@ -5,6 +5,8 @@
 #ifndef DEBUGROUTER_NATIVE_SOCKET_USB_CLIENT_H_
 #define DEBUGROUTER_NATIVE_SOCKET_USB_CLIENT_H_
 
+#include <atomic>
+
 #include "debug_router/native/base/socket_guard.h"
 #include "debug_router/native/socket/blocking_queue.h"
 #include "debug_router/native/socket/count_down_latch.h"
@@ -37,11 +39,35 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
 
   void SetConnectStatus(USBConnectStatus status);
 
- private:
-#if defined(TESTING)
-  friend class SocketServerPosixTestPeer;
+#ifdef TESTING
+  void SetListenerForTest(const std::shared_ptr<UsbClientListener> &listener) {
+    listener_ = listener;
+  }
+
+  void SetConnectedForTest(bool connected) {
+    is_connected_.store(connected, std::memory_order_relaxed);
+  }
+
+  void NotifyCloseForTest(int32_t code, const std::string &reason) {
+    NotifyCloseOnce(code, reason);
+  }
+
+  void SubmitWorkForTest(std::function<void()> task) {
+    work_thread_.submit(std::move(task));
+  }
 #endif
 
+ private:
+  enum class ReadResult {
+    kOk,
+    kClosed,
+    kStopped,
+    kError,
+  };
+
+  void BeginTransportShutdown();
+  void NotifyErrorOnce(int32_t code, const std::string &message);
+  void NotifyCloseOnce(int32_t code, const std::string &reason);
   void StartInternal(const std::shared_ptr<UsbClientListener> &listener);
   // Marks the client as stopping before closing the socket so read/write loops
   // can exit even if DisconnectInternal() is called outside Stop() later.
@@ -55,8 +81,7 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   void MessageDispatcher();
   void WriteMessage();
 
-  bool Read(char *buffer, uint32_t read_size);
-  bool ReadAndCheckMessageHeader(char *header);
+  ReadResult Read(char *buffer, uint32_t read_size, int32_t *error_code);
 
   void CloseClientSocket(SocketType socket_fd_);
   /**
@@ -97,7 +122,7 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   base::WorkThreadExecutor write_thread_;
   base::WorkThreadExecutor dispatch_thread_;
   std::shared_ptr<UsbClientListener> listener_;
-  USBConnectStatus connect_status_ = USBConnectStatus::DISCONNECTED;
+  std::atomic<USBConnectStatus> connect_status_{USBConnectStatus::DISCONNECTED};
   std::unique_ptr<CountDownLatch> latch_;
 
   base::SocketGuard socket_guard_;
@@ -108,6 +133,10 @@ class UsbClient : public std::enable_shared_from_this<UsbClient> {
   std::atomic<bool> stopping_ = {false};
   // Guards the full Stop() sequence so shutdown executes only once.
   std::atomic<bool> stop_started_ = {false};
+  // Avoids reporting the same transport failure from both read and write loops.
+  std::atomic<bool> failure_reported_ = {false};
+  // Keeps OnClose independent from OnError so both callbacks can fire once.
+  std::atomic<bool> closed_reported_ = {false};
 };
 
 }  // namespace socket_server

--- a/debug_router/native/socket/win/socket_server_win.cc
+++ b/debug_router/native/socket/win/socket_server_win.cc
@@ -21,6 +21,8 @@ SocketServerWin::SocketServerWin(
     const std::shared_ptr<SocketServerConnectionListener> &listener)
     : SocketServer(listener) {}
 
+SocketServerWin::~SocketServerWin() { Close(); }
+
 int32_t SocketServerWin::InitSocket() {
   LOGI("SocketServerWin::InitSocket");
   WSADATA wsaData;
@@ -96,11 +98,21 @@ void SocketServerWin::Start() {
     NotifyInit(GetErrorMessage(), "accept socket error");
     return;
   }
-  auto temp_usb_client = std::make_shared<UsbClient>(accept_socket_fd);
+  std::shared_ptr<UsbClient> old_client;
+  auto new_client = std::make_shared<UsbClient>(accept_socket_fd);
+  {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    old_client = temp_usb_client_;
+    temp_usb_client_ = new_client;
+  }
+  if (old_client) {
+    LOGI("close last connector, destroy temp_usb_client_.");
+    ScheduleClientStop(old_client);
+  }
   std::shared_ptr<ClientListener> listener =
       std::make_shared<ClientListener>(shared_from_this());
-  temp_usb_client->Init();
-  temp_usb_client->StartUp(listener);
+  new_client->Init();
+  new_client->StartUp(listener);
 }
 
 void SocketServerWin::CloseSocket(int socket_fd) {

--- a/debug_router/native/socket/win/socket_server_win.h
+++ b/debug_router/native/socket/win/socket_server_win.h
@@ -14,6 +14,7 @@ class SocketServerWin : public SocketServer {
  public:
   SocketServerWin(
       const std::shared_ptr<SocketServerConnectionListener> &listener);
+  ~SocketServerWin() override;
 
  private:
   inline int GetErrorMessage() override { return WSAGetLastError(); }

--- a/debug_router/native/test/BUILD.gn
+++ b/debug_router/native/test/BUILD.gn
@@ -73,7 +73,11 @@ unit_test("example_unittest") {
     "debug_router_core_concurrency_unittest.cc",
     "example_source_unittest.cc",
     "socket_server_posix_unittest.cc",
+    "socket_server_smoke_unittest.cc",
     "socket_util_unittest.cc",
+    "usb_client_unittest.cc",
+    "usb_reconnect_race_unittest.cc",
+    "websocket_task_unittest.cc",
   ]
   deps = [ ":example_testset" ]
 }

--- a/debug_router/native/test/socket_server_posix_unittest.cc
+++ b/debug_router/native/test/socket_server_posix_unittest.cc
@@ -43,7 +43,7 @@ class SocketServerPosixTestPeer {
 
   static void SubmitClientWork(const std::shared_ptr<UsbClient> &client,
                                std::function<void()> task) {
-    client->work_thread_.submit(std::move(task));
+    client->SubmitWorkForTest(std::move(task));
   }
 
   static void SubmitCleanupWork(SocketServerPosix &server,

--- a/debug_router/native/test/socket_server_smoke_unittest.cc
+++ b/debug_router/native/test/socket_server_smoke_unittest.cc
@@ -1,0 +1,37 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <memory>
+#include <string>
+
+#include "debug_router/native/socket/socket_server_api.h"
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace socket_server {
+namespace {
+
+class NoopSocketServerListener final : public SocketServerConnectionListener {
+ public:
+  void OnInit(int32_t, const std::string&) override {}
+  void OnStatusChanged(ConnectionStatus, int32_t, const std::string&) override {
+  }
+  void OnMessage(const std::string&) override {}
+};
+
+TEST(SocketServerSmokeTestSuite,
+     ConstructAndImmediateDestroyWithoutStartDoesNotCrash) {
+  ASSERT_EXIT(
+      {
+        auto listener = std::make_shared<NoopSocketServerListener>();
+        auto server = SocketServer::CreateSocketServer(listener);
+        server.reset();
+        _exit(0);
+      },
+      ::testing::ExitedWithCode(0), "");
+}
+
+}  // namespace
+}  // namespace socket_server
+}  // namespace debugrouter

--- a/debug_router/native/test/usb_client_unittest.cc
+++ b/debug_router/native/test/usb_client_unittest.cc
@@ -1,0 +1,137 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "debug_router/native/socket/usb_client.h"
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "debug_router/native/core/util.h"
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace socket_server {
+namespace {
+
+class CountingUsbClientListener final : public UsbClientListener {
+ public:
+  void OnOpen(std::shared_ptr<UsbClient> client, int32_t code,
+              const std::string& reason) override {
+    open_count.fetch_add(1, std::memory_order_relaxed);
+    cv.notify_all();
+  }
+
+  void OnClose(std::shared_ptr<UsbClient> client, int32_t code,
+               const std::string& reason) override {
+    close_count.fetch_add(1, std::memory_order_relaxed);
+    cv.notify_all();
+  }
+
+  void OnError(std::shared_ptr<UsbClient> client, int32_t code,
+               const std::string& message) override {
+    error_count.fetch_add(1, std::memory_order_relaxed);
+    cv.notify_all();
+  }
+
+  void OnMessage(std::shared_ptr<UsbClient> client,
+                 const std::string& message) override {
+    message_count.fetch_add(1, std::memory_order_relaxed);
+    cv.notify_all();
+  }
+
+  bool WaitForCount(const std::atomic<int>& counter, int expected_count,
+                    int timeout_ms) {
+    std::unique_lock<std::mutex> lock(mutex);
+    return cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&]() {
+      return counter.load(std::memory_order_relaxed) >= expected_count;
+    });
+  }
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::atomic<int> open_count{0};
+  std::atomic<int> close_count{0};
+  std::atomic<int> error_count{0};
+  std::atomic<int> message_count{0};
+};
+
+std::string PackFrame(const std::string& message) {
+  const uint32_t total_size =
+      static_cast<uint32_t>(kFrameHeaderLen + kPayloadSizeLen + message.size());
+  const uint32_t payload_block_size =
+      static_cast<uint32_t>(kPayloadSizeLen + message.size());
+  std::string result(total_size, '\0');
+  char char_array[4];
+  util::IntToCharArray(kFrameProtocolVersion, char_array);
+  memcpy(&result[0], char_array, 4);
+  util::IntToCharArray(kPTFrameTypeTextMessage, char_array);
+  memcpy(&result[4], char_array, 4);
+  util::IntToCharArray(kFrameDefaultTag, char_array);
+  memcpy(&result[8], char_array, 4);
+  util::IntToCharArray(payload_block_size, char_array);
+  memcpy(&result[12], char_array, 4);
+  util::IntToCharArray(static_cast<uint32_t>(message.size()), char_array);
+  memcpy(&result[16], char_array, 4);
+  memcpy(&result[20], message.data(), message.size());
+  return result;
+}
+
+TEST(UsbClientTestSuite, CloseBeforeOpenDoesNotNotifyListener) {
+  auto client = std::make_shared<UsbClient>(kInvalidSocket);
+  auto listener = std::make_shared<CountingUsbClientListener>();
+  client->SetListenerForTest(listener);
+
+  client->NotifyCloseForTest(0, "before open");
+
+  EXPECT_EQ(listener->close_count.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST(UsbClientTestSuite, CloseAfterOpenNotifiesOnlyOnce) {
+  auto client = std::make_shared<UsbClient>(kInvalidSocket);
+  auto listener = std::make_shared<CountingUsbClientListener>();
+  client->SetListenerForTest(listener);
+  client->SetConnectedForTest(true);
+
+  client->NotifyCloseForTest(0, "after open");
+  client->NotifyCloseForTest(0, "after open again");
+
+  EXPECT_EQ(listener->close_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST(UsbClientTestSuite, PeerEOFNotifiesCloseWithoutError) {
+  int sockets[2] = {-1, -1};
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+
+  auto client = std::make_shared<UsbClient>(sockets[0]);
+  auto listener = std::make_shared<CountingUsbClientListener>();
+  client->Init();
+  client->StartUp(listener);
+
+  const std::string frame = PackFrame(R"({"event":"Initialize","data":-1})");
+  ASSERT_EQ(write(sockets[1], frame.data(), frame.size()),
+            static_cast<ssize_t>(frame.size()));
+  ASSERT_EQ(shutdown(sockets[1], SHUT_WR), 0);
+
+  EXPECT_TRUE(listener->WaitForCount(listener->open_count, 1, 3000));
+  EXPECT_TRUE(listener->WaitForCount(listener->message_count, 1, 3000));
+  EXPECT_TRUE(listener->WaitForCount(listener->close_count, 1, 3000));
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 0);
+  EXPECT_GT(client.use_count(), 1);
+
+  close(sockets[1]);
+  client->Stop();
+}
+
+}  // namespace
+}  // namespace socket_server
+}  // namespace debugrouter

--- a/debug_router/native/test/usb_reconnect_race_unittest.cc
+++ b/debug_router/native/test/usb_reconnect_race_unittest.cc
@@ -1,0 +1,449 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "debug_router/native/core/debug_router_core.h"
+#include "debug_router/native/core/util.h"
+#include "debug_router/native/socket/socket_server_api.h"
+#include "debug_router/native/thread/debug_router_executor.h"
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace socket_server {
+namespace {
+
+std::string PackFrame(const std::string& payload) {
+  const uint32_t payload_size = static_cast<uint32_t>(payload.size());
+  const uint32_t total_size = kFrameHeaderLen + kPayloadSizeLen + payload_size;
+  std::string result(total_size, '\0');
+  char* buffer = &result[0];
+  char char_array[4];
+
+  util::IntToCharArray(kFrameProtocolVersion, char_array);
+  memcpy(buffer, char_array, 4);
+  util::IntToCharArray(kPTFrameTypeTextMessage, char_array);
+  memcpy(buffer + 4, char_array, 4);
+  util::IntToCharArray(kFrameDefaultTag, char_array);
+  memcpy(buffer + 8, char_array, 4);
+  util::IntToCharArray(payload_size + kPayloadSizeLen, char_array);
+  memcpy(buffer + 12, char_array, 4);
+  util::IntToCharArray(payload_size, char_array);
+  memcpy(buffer + 16, char_array, 4);
+  memcpy(buffer + 20, payload.data(), payload_size);
+  return result;
+}
+
+int ConnectToPort(int port) {
+  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    return -1;
+  }
+
+  sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(port));
+  addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+  if (connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    close(sock);
+    return -1;
+  }
+  return sock;
+}
+
+bool SendAll(int sock, const std::string& data) {
+  size_t sent = 0;
+  while (sent < data.size()) {
+    ssize_t n = send(sock, data.data() + sent, data.size() - sent, 0);
+    if (n <= 0) {
+      return false;
+    }
+    sent += static_cast<size_t>(n);
+  }
+  return true;
+}
+
+bool WaitForExecutorTask(int timeout_ms) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool finished = false;
+  thread::DebugRouterExecutor::GetInstance().Post([&]() {
+    std::lock_guard<std::mutex> lock(mutex);
+    finished = true;
+    cv.notify_all();
+  });
+  std::unique_lock<std::mutex> lock(mutex);
+  return cv.wait_for(lock, std::chrono::milliseconds(timeout_ms),
+                     [&]() { return finished; });
+}
+
+class RecordingSocketServerListener final
+    : public SocketServerConnectionListener {
+ public:
+  void OnInit(int32_t code, const std::string& info) override {}
+
+  void OnStatusChanged(ConnectionStatus status, int32_t code,
+                       const std::string& info) override {
+    if (status == kConnected) {
+      connected_count.fetch_add(1, std::memory_order_relaxed);
+    } else if (status == kDisconnected) {
+      disconnected_count.fetch_add(1, std::memory_order_relaxed);
+    } else if (status == kError) {
+      error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    cv.notify_all();
+  }
+
+  void OnMessage(const std::string& message) override {}
+
+  bool WaitForCount(const std::atomic<int>& counter, int expected_count,
+                    int timeout_ms) {
+    std::unique_lock<std::mutex> lock(mutex);
+    return cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&]() {
+      return counter.load(std::memory_order_relaxed) >= expected_count;
+    });
+  }
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::atomic<int> connected_count{0};
+  std::atomic<int> disconnected_count{0};
+  std::atomic<int> error_count{0};
+};
+
+class TestSocketServer final : public SocketServer {
+ public:
+  explicit TestSocketServer(
+      const std::shared_ptr<SocketServerConnectionListener>& listener)
+      : SocketServer(listener) {}
+
+  void Start() override {}
+  int GetErrorMessage() override { return 0; }
+  void CloseSocket(int socket_fd) override {}
+
+  void SeedClients(const std::shared_ptr<UsbClient>& current,
+                   const std::shared_ptr<UsbClient>& pending) {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    usb_client_ = current;
+    temp_usb_client_ = pending;
+  }
+
+  std::shared_ptr<UsbClient> CurrentClient() {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    return usb_client_;
+  }
+
+  bool WaitUntil(std::function<bool()> predicate, int timeout_ms) {
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (predicate()) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return predicate();
+  }
+};
+
+class UsbReconnectRaceTestSuite : public testing::Test {
+ protected:
+  static void SetUpTestSuite() { core::DebugRouterCore::GetInstance(); }
+
+  static void TearDownTestSuite() {}
+};
+
+class IntegrationConnectionListener final
+    : public SocketServerConnectionListener {
+ public:
+  void OnInit(int32_t code, const std::string& info) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    init_code_ = code;
+    init_info_ = info;
+    cv_.notify_all();
+  }
+
+  void OnStatusChanged(ConnectionStatus status, int32_t code,
+                       const std::string& info) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_history_.push_back(status);
+    cv_.notify_all();
+  }
+
+  void OnMessage(const std::string& message) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    messages_.push_back(message);
+    cv_.notify_all();
+  }
+
+  bool WaitForInit(int timeout_ms) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&]() {
+      return init_code_ == 0 && init_info_.rfind("port:", 0) == 0;
+    });
+  }
+
+  bool WaitForStatusCount(ConnectionStatus status, size_t expected_count,
+                          int timeout_ms) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms), [&]() {
+      return CountStatusLocked(status) >= expected_count;
+    });
+  }
+
+  bool WaitForMessages(size_t expected_count, int timeout_ms) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms),
+                        [&]() { return messages_.size() >= expected_count; });
+  }
+
+  int Port() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (init_info_.rfind("port:", 0) != 0) {
+      return -1;
+    }
+    return std::stoi(init_info_.substr(5));
+  }
+
+  size_t StatusCount(ConnectionStatus status) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return CountStatusLocked(status);
+  }
+
+  std::vector<std::string> Messages() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return messages_;
+  }
+
+ private:
+  size_t CountStatusLocked(ConnectionStatus status) const {
+    size_t count = 0;
+    for (ConnectionStatus current : status_history_) {
+      if (current == status) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int32_t init_code_ = -1;
+  std::string init_info_;
+  std::vector<ConnectionStatus> status_history_;
+  std::vector<std::string> messages_;
+};
+
+class UsbReconnectIntegrationTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() { core::DebugRouterCore::GetInstance(); }
+
+  void SetUp() override {
+    listener_ = std::make_shared<IntegrationConnectionListener>();
+    server_ = SocketServer::CreateSocketServer(listener_);
+    server_->Init();
+    server_->StartServer();
+    ASSERT_TRUE(listener_->WaitForInit(5000));
+    port_ = listener_->Port();
+    ASSERT_GT(port_, 0);
+  }
+
+  void TearDown() override {
+    if (server_) {
+      server_->StopServer();
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      server_.reset();
+    }
+  }
+
+  std::shared_ptr<IntegrationConnectionListener> listener_;
+  std::shared_ptr<SocketServer> server_;
+  int port_ = -1;
+};
+
+TEST_F(UsbReconnectRaceTestSuite,
+       StaleOpenAfterNextAcceptDoesNotPromoteOldClient) {
+  auto listener = std::make_shared<RecordingSocketServerListener>();
+  auto server = std::shared_ptr<TestSocketServer>(
+      new TestSocketServer(listener), [](TestSocketServer*) {});
+  auto old_client = std::make_shared<UsbClient>(kInvalidSocket);
+  auto new_client = std::make_shared<UsbClient>(kInvalidSocket);
+
+  server->SeedClients(nullptr, new_client);
+
+  server->HandleOnOpenStatus(old_client, 0, "Init Success!");
+  ASSERT_TRUE(WaitForExecutorTask(1000));
+  EXPECT_EQ(listener->connected_count.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(server->CurrentClient(), nullptr);
+
+  server->HandleOnOpenStatus(new_client, 0, "Init Success!");
+  ASSERT_TRUE(listener->WaitForCount(listener->connected_count, 1, 1000));
+  EXPECT_EQ(listener->connected_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(server->CurrentClient(), new_client);
+}
+
+TEST_F(UsbReconnectRaceTestSuite,
+       PromotedCloseBeforePendingFailureStillNotifiesDisconnect) {
+  auto listener = std::make_shared<RecordingSocketServerListener>();
+  auto server = std::shared_ptr<TestSocketServer>(
+      new TestSocketServer(listener), [](TestSocketServer*) {});
+  auto old_client = std::make_shared<UsbClient>(kInvalidSocket);
+  auto new_client = std::make_shared<UsbClient>(kInvalidSocket);
+
+  server->SeedClients(nullptr, old_client);
+  server->HandleOnOpenStatus(old_client, 0, "Init Success!");
+  ASSERT_TRUE(listener->WaitForCount(listener->connected_count, 1, 1000));
+  EXPECT_EQ(server->CurrentClient(), old_client);
+
+  server->SeedClients(old_client, new_client);
+  server->HandleOnCloseStatus(old_client, ConnectionStatus::kDisconnected, 0,
+                              "peer closed connection (EOF)");
+  ASSERT_TRUE(server->WaitUntil(
+      [&]() { return server->CurrentClient() == nullptr; }, 1000));
+  ASSERT_TRUE(listener->WaitForCount(listener->disconnected_count, 1, 1000));
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 0);
+
+  server->HandleOnCloseStatus(new_client, ConnectionStatus::kDisconnected, 0,
+                              "peer closed connection (EOF)");
+  ASSERT_TRUE(WaitForExecutorTask(1000));
+  EXPECT_EQ(listener->connected_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->disconnected_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST_F(UsbReconnectRaceTestSuite,
+       PromotedErrorBeforePendingFailureStillNotifiesError) {
+  auto listener = std::make_shared<RecordingSocketServerListener>();
+  auto server = std::shared_ptr<TestSocketServer>(
+      new TestSocketServer(listener), [](TestSocketServer*) {});
+  auto old_client = std::make_shared<UsbClient>(kInvalidSocket);
+  auto new_client = std::make_shared<UsbClient>(kInvalidSocket);
+
+  server->SeedClients(nullptr, old_client);
+  server->HandleOnOpenStatus(old_client, 0, "Init Success!");
+  ASSERT_TRUE(listener->WaitForCount(listener->connected_count, 1, 1000));
+  EXPECT_EQ(server->CurrentClient(), old_client);
+
+  server->SeedClients(old_client, new_client);
+  server->HandleOnErrorStatus(old_client, ConnectionStatus::kError, 32,
+                              "broken pipe");
+  ASSERT_TRUE(server->WaitUntil(
+      [&]() { return server->CurrentClient() == nullptr; }, 1000));
+  ASSERT_TRUE(listener->WaitForCount(listener->error_count, 1, 1000));
+  EXPECT_EQ(listener->disconnected_count.load(std::memory_order_relaxed), 0);
+
+  server->HandleOnErrorStatus(new_client, ConnectionStatus::kError, 32,
+                              "broken pipe");
+  ASSERT_TRUE(WaitForExecutorTask(1000));
+  EXPECT_EQ(listener->connected_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->disconnected_count.load(std::memory_order_relaxed), 0);
+
+  server->HandleOnCloseStatus(old_client, ConnectionStatus::kDisconnected, 0,
+                              "peer closed connection (EOF)");
+  ASSERT_TRUE(WaitForExecutorTask(1000));
+  EXPECT_EQ(listener->connected_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->error_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(listener->disconnected_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST_F(UsbReconnectIntegrationTest,
+       ImmediateReconnectStillDeliversNewConnectionMessages) {
+  int sock_a = ConnectToPort(port_);
+  ASSERT_GE(sock_a, 0);
+  ASSERT_TRUE(
+      SendAll(sock_a, PackFrame(R"({"event":"Initialize","data":-1})")));
+  ASSERT_TRUE(listener_->WaitForStatusCount(kConnected, 1, 3000));
+  ASSERT_TRUE(listener_->WaitForMessages(1, 3000));
+
+  close(sock_a);
+
+  int sock_b = ConnectToPort(port_);
+  ASSERT_GE(sock_b, 0);
+  const size_t connected_before_b = listener_->StatusCount(kConnected);
+  const size_t disconnected_before_b = listener_->StatusCount(kDisconnected);
+  const size_t error_before_b = listener_->StatusCount(kError);
+  const size_t messages_before_b = listener_->Messages().size();
+
+  const std::string init_b = R"({"event":"Initialize","data":-1})";
+  const std::string list_session =
+      R"({"event":"Customized","data":{"type":"ListSession"}})";
+  ASSERT_TRUE(SendAll(sock_b, PackFrame(init_b) + PackFrame(list_session)));
+
+  ASSERT_TRUE(
+      listener_->WaitForStatusCount(kConnected, connected_before_b + 1, 3000));
+  ASSERT_TRUE(listener_->WaitForMessages(messages_before_b + 2, 3000));
+  EXPECT_EQ(listener_->StatusCount(kError), error_before_b);
+
+  std::vector<std::string> messages = listener_->Messages();
+  ASSERT_GE(messages.size(), messages_before_b + 2);
+  EXPECT_EQ(messages[messages.size() - 2], init_b);
+  EXPECT_EQ(messages[messages.size() - 1], list_session);
+
+  close(sock_b);
+  ASSERT_TRUE(listener_->WaitForStatusCount(kDisconnected,
+                                            disconnected_before_b + 1, 3000));
+  EXPECT_EQ(listener_->StatusCount(kError), error_before_b);
+}
+
+TEST_F(UsbReconnectIntegrationTest, StressNoWaitReconnect) {
+  const int num_reconnects = 20;
+  const std::string init_msg = R"({"event":"Initialize","data":-1})";
+  const std::string cmd_msg =
+      R"({"event":"Customized","data":{"type":"ListSession"}})";
+
+  int expected_messages = 0;
+
+  for (int i = 0; i < num_reconnects; i++) {
+    int sock = ConnectToPort(port_);
+    if (sock < 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      sock = ConnectToPort(port_);
+    }
+    ASSERT_GE(sock, 0) << "Failed to connect on iteration " << i;
+
+    std::string bulk;
+    bulk += PackFrame(init_msg);
+    expected_messages++;
+    for (int j = 0; j < 3; j++) {
+      bulk += PackFrame(cmd_msg);
+      expected_messages++;
+    }
+    ASSERT_TRUE(SendAll(sock, bulk));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    close(sock);
+  }
+
+  const bool got_all = listener_->WaitForMessages(expected_messages, 15000);
+  const std::vector<std::string> all_msgs = listener_->Messages();
+  std::cout << "Stress test: Expected " << expected_messages
+            << " messages, got " << all_msgs.size() << std::endl;
+
+  EXPECT_TRUE(got_all) << "Expected " << expected_messages
+                       << " messages but got " << all_msgs.size()
+                       << ". Messages were dropped during stress reconnect "
+                          "test.";
+}
+
+}  // namespace
+}  // namespace socket_server
+}  // namespace debugrouter

--- a/debug_router/native/test/websocket_task_unittest.cc
+++ b/debug_router/native/test/websocket_task_unittest.cc
@@ -1,0 +1,147 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "debug_router/native/net/websocket_task.h"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace net {
+namespace {
+
+class FakeMessageTransceiver final : public core::MessageTransceiver {
+ public:
+  bool Connect(const std::string& url) override { return true; }
+  void Disconnect() override {}
+  void Send(const std::string& data) override {}
+  core::ConnectionType GetType() override {
+    return core::ConnectionType::kWebSocket;
+  }
+  void StartServer() override {}
+  void StopServer() override {}
+};
+
+class CountingDelegate final : public core::MessageTransceiverDelegate {
+ public:
+  void OnOpen(
+      const std::shared_ptr<core::MessageTransceiver>& transceiver) override {}
+
+  void OnClosed(
+      const std::shared_ptr<core::MessageTransceiver>& transceiver) override {
+    closed_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void OnFailure(const std::shared_ptr<core::MessageTransceiver>& transceiver,
+                 const std::string& error_message, int error_code) override {
+    failure_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void OnMessage(
+      const std::string& message,
+      const std::shared_ptr<core::MessageTransceiver>& transceiver) override {}
+
+  void OnInit(const std::shared_ptr<core::MessageTransceiver>& transceiver,
+              int32_t code, const std::string& info) override {}
+
+  std::atomic<int> closed_count{0};
+  std::atomic<int> failure_count{0};
+};
+
+TEST(WebSocketTaskTestSuite, ConcurrentStopOnlyNotifiesCloseOnce) {
+  auto transceiver = std::make_shared<FakeMessageTransceiver>();
+  CountingDelegate delegate;
+  transceiver->SetDelegate(&delegate);
+
+  auto task = std::make_unique<WebSocketTask>(transceiver, "ws://127.0.0.1");
+  task->SetConnectedForTest(true);
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 4; ++i) {
+    threads.emplace_back([&task]() { task->Stop(); });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(delegate.failure_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST(WebSocketTaskTestSuite, StopBeforeOpenDoesNotNotifyClose) {
+  auto transceiver = std::make_shared<FakeMessageTransceiver>();
+  CountingDelegate delegate;
+  transceiver->SetDelegate(&delegate);
+
+  auto task = std::make_unique<WebSocketTask>(transceiver, "ws://127.0.0.1");
+
+  task->Stop();
+
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(delegate.failure_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST(WebSocketTaskTestSuite, FailureBeforeOpenDoesNotNotifyClose) {
+  auto transceiver = std::make_shared<FakeMessageTransceiver>();
+  CountingDelegate delegate;
+  transceiver->SetDelegate(&delegate);
+
+  auto task = std::make_unique<WebSocketTask>(transceiver, "ws://127.0.0.1");
+
+  task->NotifyFailureForTest("connect failed", -1);
+
+  EXPECT_EQ(delegate.failure_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 0);
+}
+
+TEST(WebSocketTaskTestSuite, FailureAlsoNotifiesCloseOnce) {
+  auto transceiver = std::make_shared<FakeMessageTransceiver>();
+  CountingDelegate delegate;
+  transceiver->SetDelegate(&delegate);
+
+  auto task = std::make_unique<WebSocketTask>(transceiver, "ws://127.0.0.1");
+  task->SetConnectedForTest(true);
+
+  task->NotifyFailureForTest("send failed", -1);
+
+  EXPECT_EQ(delegate.failure_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 1);
+
+  task->NotifyCloseForTest();
+  task->NotifyFailureForTest("send failed again", -2);
+
+  EXPECT_EQ(delegate.failure_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 1);
+}
+
+TEST(WebSocketTaskTestSuite, ConcurrentStopAndFailureCloseOnlyOnce) {
+  auto transceiver = std::make_shared<FakeMessageTransceiver>();
+  CountingDelegate delegate;
+  transceiver->SetDelegate(&delegate);
+
+  auto task = std::make_unique<WebSocketTask>(transceiver, "ws://127.0.0.1");
+  task->SetConnectedForTest(true);
+
+  std::thread stop_thread([&task]() { task->Stop(); });
+  std::thread failure_thread(
+      [&task]() { task->NotifyFailureForTest("send failed", -1); });
+
+  stop_thread.join();
+  failure_thread.join();
+
+  const int failure_count =
+      delegate.failure_count.load(std::memory_order_relaxed);
+  EXPECT_EQ(delegate.closed_count.load(std::memory_order_relaxed), 1);
+  EXPECT_GE(failure_count, 0);
+  EXPECT_LE(failure_count, 1);
+}
+
+}  // namespace
+}  // namespace net
+}  // namespace debugrouter


### PR DESCRIPTION
- shut down UsbClient/WebSocketTask transports promptly during stop/failure
- dedupe UsbClient/WebSocketTask failure and close notifications
- serialize stale UsbClient cleanup during reconnect handover
- unify socket server close/teardown handling across socket backends
- add reconnect and concurrency regression tests