### PR TITLE
[Optimize]Decouple EnableSingleSession from USB server start/stop

### DIFF
--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -334,17 +334,12 @@ int32_t DebugRouterCore::GetUSBPort() {
 
 void DebugRouterCore::Pull(int32_t session_id_) {
   LOGI("pull session: " << session_id_);
-  bool removed_enabled_session = false;
   if (!enable_all_sessions_.load(std::memory_order_relaxed)) {
     std::unique_lock lock(enabled_sessions_mutex_);
-    removed_enabled_session = enabled_session_ids_.erase(session_id_) > 0;
+    enabled_session_ids_.erase(session_id_);
   }
-  // Server availability only depends on debug channel / enable-all /
-  // enabled-session ids. Pull() only needs to refresh the server state when it
-  // actually removes an enabled session from that decision set.
-  if (removed_enabled_session) {
-    UpdateServerState();
-  }
+  // Server availability no longer depends on enabled-session ids. Pull() only
+  // updates the filter set used by isActiveSession().
   {
     std::unique_lock lock(slots_mutex_);
     slots_.erase(session_id_);
@@ -800,12 +795,8 @@ std::string DebugRouterCore::GetConnectionStateMsg(ConnectionState state) {
 }
 
 bool DebugRouterCore::ShouldServerRun() {
-  if (enable_all_sessions_.load(std::memory_order_relaxed) ||
-      debug_channel_enabled_.load(std::memory_order_relaxed)) {
-    return true;
-  }
-  std::shared_lock lock(enabled_sessions_mutex_);
-  return !enabled_session_ids_.empty();
+  return enable_all_sessions_.load(std::memory_order_relaxed) ||
+         debug_channel_enabled_.load(std::memory_order_relaxed);
 }
 
 void DebugRouterCore::UpdateServerState() {
@@ -865,13 +856,9 @@ void DebugRouterCore::EnableSingleSession(int32_t session_id) {
     return;
   }
   LOGI("enableSingleSession: " << session_id);
-  bool inserted = false;
   {
     std::unique_lock lock(enabled_sessions_mutex_);
-    inserted = enabled_session_ids_.insert(session_id).second;
-  }
-  if (inserted) {
-    UpdateServerState();
+    enabled_session_ids_.insert(session_id);
   }
 }
 

--- a/debug_router/native/core/debug_router_core.h
+++ b/debug_router/native/core/debug_router_core.h
@@ -137,8 +137,8 @@ class DebugRouterCore : public MessageTransceiverDelegate {
 
   // these two methods are conflictive, only one of them can be enabled
   void EnableAllSessions();
-  // for online debug, could only debug needed sessions, work with
-  // enabled_session_ids_. session_id must be > 0.
+  // Records the session ids allowed by isActiveSession(). This does not
+  // affect whether the local server stays available. session_id must be > 0.
   void EnableSingleSession(int32_t session_id);
   // Debug channel only controls whether the server should stay available.
   // It does not bypass session filtering or alter message routing semantics.

--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -23,15 +23,16 @@ SocketServerPosix::SocketServerPosix(
 int32_t SocketServerPosix::InitSocket() {
   LOGI("start new");
 
-  socket_fd_ = socket(AF_INET, SOCK_STREAM, 0);
-  if (socket_fd_ == kInvalidSocket) {
+  const SocketType socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  socket_fd_.store(socket_fd, std::memory_order_release);
+  if (socket_fd == kInvalidSocket) {
     LOGE("create socket error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "create socket error");
     return kInvalidPort;
   }
 
   int on = 1;
-  if (setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
     Close();
     LOGE("setsockopt error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "setsockopt error");
@@ -48,7 +49,7 @@ int32_t SocketServerPosix::InitSocket() {
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-    if (bind(socket_fd_, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+    if (bind(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
       flag = true;
       break;
     }
@@ -65,7 +66,7 @@ int32_t SocketServerPosix::InitSocket() {
 
   LOGI("bind port:" << port);
 
-  if (listen(socket_fd_, kConnectionQueueMaxLength) != 0) {
+  if (listen(socket_fd, kConnectionQueueMaxLength) != 0) {
     Close();
     LOGE("listen error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "listen error");
@@ -75,19 +76,21 @@ int32_t SocketServerPosix::InitSocket() {
 }
 
 void SocketServerPosix::Start() {
-  if (socket_fd_ == kInvalidSocket) {
+  SocketType socket_fd = socket_fd_.load(std::memory_order_acquire);
+  if (socket_fd == kInvalidSocket) {
     int32_t port = kInvalidPort;
     port = InitSocket();
     if (port == kInvalidPort) {
       return;
     }
     NotifyInit(0, "port:" + std::to_string(port));
+    socket_fd = socket_fd_.load(std::memory_order_acquire);
   }
-  LOGI("server socket:" << socket_fd_);
+  LOGI("server socket:" << socket_fd);
   struct sockaddr_in addr;
   socklen_t addrLen = sizeof(addr);
   SocketType accept_socket_fd =
-      accept(socket_fd_, (struct sockaddr *)(&addr), &addrLen);
+      accept(socket_fd, (struct sockaddr *)(&addr), &addrLen);
   if (accept_socket_fd == kInvalidSocket) {
     Close();
     LOGE("accept socket error:" << GetErrorMessage());

--- a/debug_router/native/socket/socket_server_api.cc
+++ b/debug_router/native/socket/socket_server_api.cc
@@ -25,28 +25,55 @@ std::shared_ptr<SocketServer> SocketServer::CreateSocketServer(
 
 SocketServer::SocketServer(
     const std::shared_ptr<SocketServerConnectionListener> &listener)
-    : listener_(listener), usb_client_(nullptr) {}
+    : listener_(listener), usb_client_(nullptr) {
+  clean_executor_.init();
+}
+
+void SocketServer::ScheduleClientStop(
+    const std::shared_ptr<UsbClient> &client) {
+  if (!client) {
+    return;
+  }
+  clean_executor_.submit([client]() { client->Stop(); });
+}
 
 bool SocketServer::Send(const std::string &message) {
-  if (!usb_client_) {
+  std::shared_ptr<UsbClient> client;
+  {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    client = usb_client_;
+  }
+  if (!client) {
     LOGI("SocketServerApi Send: client is null.");
     return false;
   }
-  return usb_client_->Send(message);
+  return client->Send(message);
 }
 
 void SocketServer::HandleOnOpenStatus(std::shared_ptr<UsbClient> client,
                                       int32_t code, const std::string &reason) {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    std::shared_ptr<UsbClient> old_client_ = usb_client_;
-    LOGI("SocketServerApi OnOpen: replace old client.");
-    if (old_client_) {
-      LOGI("SocketServerApi HandleOnOpenStatus: stop old client.");
-      old_client_->Stop();
+    std::shared_ptr<UsbClient> old_client_;
+    bool should_notify = false;
+    {
+      std::lock_guard<std::mutex> lock(client_lock_);
+      if (temp_usb_client_ != client) {
+        LOGI("SocketServerApi OnOpen: stale client open ignored.");
+        return;
+      }
+      old_client_ = usb_client_;
+      usb_client_ = client;
+      should_notify = true;
     }
-    usb_client_ = client;
-    if (auto listener = listener_.lock()) {
-      listener->OnStatusChanged(kConnected, code, reason);
+    LOGI("SocketServerApi OnOpen: replace old client.");
+    if (old_client_ && old_client_ != client) {
+      LOGI("SocketServerApi HandleOnOpenStatus: stop old client.");
+      ScheduleClientStop(old_client_);
+    }
+    if (should_notify) {
+      if (auto listener = listener_.lock()) {
+        listener->OnStatusChanged(kConnected, code, reason);
+      }
     }
   });
 }
@@ -54,7 +81,12 @@ void SocketServer::HandleOnOpenStatus(std::shared_ptr<UsbClient> client,
 void SocketServer::HandleOnMessageStatus(std::shared_ptr<UsbClient> client,
                                          const std::string &message) {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    if (!usb_client_ || usb_client_ != client) {
+    bool is_current_client = false;
+    {
+      std::lock_guard<std::mutex> lock(client_lock_);
+      is_current_client = usb_client_ && usb_client_ == client;
+    }
+    if (!is_current_client) {
       LOGI("SocketServerApi OnMessage: client is null or not match.");
       return;
     }
@@ -68,19 +100,49 @@ void SocketServer::HandleOnCloseStatus(std::shared_ptr<UsbClient> client,
                                        ConnectionStatus status, int32_t code,
                                        const std::string &reason) {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    if (!usb_client_ || usb_client_ != client) {
+    std::shared_ptr<UsbClient> client_to_stop;
+    bool should_notify = false;
+    // True if this callback tore down a client that had already been
+    // promoted to usb_client_. Such clients must still produce a status
+    // notification even if their close/error races with a newer accept.
+    bool cleared_promoted_client = false;
+    {
+      std::lock_guard<std::mutex> lock(client_lock_);
+      const bool superseded_by_new_accept =
+          temp_usb_client_ && temp_usb_client_ != client;
+      if (superseded_by_new_accept || !usb_client_ || usb_client_ != client) {
+        if (usb_client_ == client) {
+          usb_client_ = nullptr;
+          cleared_promoted_client = true;
+        }
+        if (temp_usb_client_ == client) {
+          temp_usb_client_ = nullptr;
+        }
+        client_to_stop = client;
+      } else {
+        LOGI(
+            "SocketServerApi HandleOnCloseStatus: close curr client for "
+            "OnClose.");
+        client_to_stop = usb_client_;
+        usb_client_ = nullptr;
+        if (temp_usb_client_ == client) {
+          temp_usb_client_ = nullptr;
+        }
+        should_notify = true;
+      }
+    }
+    if (!should_notify && !cleared_promoted_client) {
       LOGI(
-          "SocketServerApi OnClose: curr client is null or not match, stop "
-          "error client.");
-      client->Stop();
-      if (auto listener = listener_.lock()) {
-        listener->OnStatusChanged(status, code, reason);
+          "SocketServerApi OnClose: stale client closed, stop stale client "
+          "without notifying current connection.");
+      if (client_to_stop) {
+        ScheduleClientStop(client_to_stop);
       }
       return;
     }
-    LOGI("SocketServerApi HandleOnCloseStatus: close curr client for OnClose.");
-    usb_client_->Stop();
-    usb_client_ = nullptr;
+    if (client_to_stop) {
+      ScheduleClientStop(client_to_stop);
+    }
     if (auto listener = listener_.lock()) {
       listener->OnStatusChanged(status, code, reason);
     }
@@ -91,16 +153,49 @@ void SocketServer::HandleOnErrorStatus(std::shared_ptr<UsbClient> client,
                                        ConnectionStatus status, int32_t code,
                                        const std::string &reason) {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    if (!usb_client_ || usb_client_ != client) {
+    std::shared_ptr<UsbClient> client_to_stop;
+    bool should_notify = false;
+    // True if this callback tore down a client that had already been
+    // promoted to usb_client_. Such clients must still produce a status
+    // notification even if their close/error races with a newer accept.
+    bool cleared_promoted_client = false;
+    {
+      std::lock_guard<std::mutex> lock(client_lock_);
+      const bool superseded_by_new_accept =
+          temp_usb_client_ && temp_usb_client_ != client;
+      if (superseded_by_new_accept || !usb_client_ || usb_client_ != client) {
+        if (usb_client_ == client) {
+          usb_client_ = nullptr;
+          cleared_promoted_client = true;
+        }
+        if (temp_usb_client_ == client) {
+          temp_usb_client_ = nullptr;
+        }
+        client_to_stop = client;
+      } else {
+        LOGI(
+            "SocketServerApi HandleOnErrorStatus: close curr client for "
+            "OnError.");
+        client_to_stop = usb_client_;
+        usb_client_ = nullptr;
+        if (temp_usb_client_ == client) {
+          temp_usb_client_ = nullptr;
+        }
+        should_notify = true;
+      }
+    }
+    if (!should_notify && !cleared_promoted_client) {
       LOGI(
-          "SocketServerApi OnError: client is null or not match, stop error "
-          "client.");
-      client->Stop();
+          "SocketServerApi OnError: stale client errored, stop stale client "
+          "without notifying current connection.");
+      if (client_to_stop) {
+        ScheduleClientStop(client_to_stop);
+      }
       return;
     }
-    LOGI("SocketServerApi HandleOnErrorStatus: close curr client for OnError.");
-    usb_client_->Stop();
-    usb_client_ = nullptr;
+    if (client_to_stop) {
+      ScheduleClientStop(client_to_stop);
+    }
     if (auto listener = listener_.lock()) {
       listener->OnStatusChanged(status, code, reason);
     }
@@ -126,22 +221,32 @@ void SocketServer::setEnableServer(bool enable) {
 void SocketServer::StartServer() { setEnableServer(true); }
 
 void SocketServer::StopServer() {
+  std::shared_ptr<UsbClient> current_client;
+  std::shared_ptr<UsbClient> pending_client;
   setEnableServer(false);
   // Close socket if it's valid
-  if (socket_fd_ != kInvalidSocket) {
+  SocketType socket_fd = socket_fd_.load(std::memory_order_acquire);
+  if (socket_fd != kInvalidSocket) {
 #ifdef _WIN32
-    shutdown(socket_fd_, SD_BOTH);
+    shutdown(socket_fd, SD_BOTH);
 #else
-    shutdown(socket_fd_, SHUT_RDWR);
+    shutdown(socket_fd, SHUT_RDWR);
 #endif
   }
 
   Close();
-  if (usb_client_) {
-    usb_client_->Stop();
+  {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    current_client = usb_client_;
+    pending_client = temp_usb_client_;
+    usb_client_ = nullptr;
+    temp_usb_client_ = nullptr;
   }
-  if (temp_usb_client_) {
-    temp_usb_client_->Stop();
+  if (current_client) {
+    current_client->Stop();
+  }
+  if (pending_client && pending_client != current_client) {
+    pending_client->Stop();
   }
 }
 
@@ -168,28 +273,47 @@ void SocketServer::Init() {
 
 // close server socket
 void SocketServer::Close() {
-  LOGI("SocketServer::Close server socket_fd_:" << socket_fd_);
-  CloseSocket(socket_fd_);
-  socket_fd_ = kInvalidSocket;
+  SocketType socket_fd =
+      socket_fd_.exchange(kInvalidSocket, std::memory_order_acq_rel);
+  LOGI("SocketServer::Close server socket_fd_:" << socket_fd);
+  CloseSocket(socket_fd);
 }
 
 void SocketServer::Disconnect() {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    if (usb_client_) {
-      LOGI("SocketServerApi Disconnect: stop curr client.");
-      usb_client_->Stop();
+    std::shared_ptr<UsbClient> client_to_stop;
+    {
+      std::lock_guard<std::mutex> lock(client_lock_);
+      client_to_stop = usb_client_;
       usb_client_ = nullptr;
+      if (temp_usb_client_ == client_to_stop) {
+        temp_usb_client_ = nullptr;
+      }
+    }
+    if (client_to_stop) {
+      LOGI("SocketServerApi Disconnect: stop curr client.");
+      ScheduleClientStop(client_to_stop);
     }
   });
 }
 
 SocketServer::~SocketServer() {
   LOGI("SocketServer::~SocketServer");
-  if (usb_client_) {
-    usb_client_->Stop();
+  clean_executor_.shutdown();
+  std::shared_ptr<UsbClient> current_client;
+  std::shared_ptr<UsbClient> pending_client;
+  {
+    std::lock_guard<std::mutex> lock(client_lock_);
+    current_client = usb_client_;
+    pending_client = temp_usb_client_;
+    usb_client_ = nullptr;
+    temp_usb_client_ = nullptr;
   }
-  if (temp_usb_client_) {
-    temp_usb_client_->Stop();
+  if (current_client) {
+    current_client->Stop();
+  }
+  if (pending_client && pending_client != current_client) {
+    pending_client->Stop();
   }
   Close();
 }

--- a/debug_router/native/socket/socket_server_api.h
+++ b/debug_router/native/socket/socket_server_api.h
@@ -5,6 +5,7 @@
 #ifndef DEBUGROUTER_NATIVE_SOCKET_SOCKET_SERVER_API_H
 #define DEBUGROUTER_NATIVE_SOCKET_SOCKET_SERVER_API_H
 
+#include <atomic>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -14,6 +15,7 @@
 #include "debug_router/native/socket/count_down_latch.h"
 #include "debug_router/native/socket/socket_server_type.h"
 #include "debug_router/native/socket/usb_client_listener.h"
+#include "debug_router/native/socket/work_thread_executor.h"
 
 namespace debugrouter {
 namespace socket_server {
@@ -46,6 +48,7 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   void HandleOnErrorStatus(std::shared_ptr<UsbClient> client,
                            ConnectionStatus status, int32_t code,
                            const std::string &reason);
+  void ScheduleClientStop(const std::shared_ptr<UsbClient> &client);
 
   static std::shared_ptr<SocketServer> CreateSocketServer(
       const std::shared_ptr<SocketServerConnectionListener> &listener);
@@ -69,10 +72,12 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   std::condition_variable queue_available_;
   std::unique_ptr<CountDownLatch> latch_;
   std::mutex queue_lock_;
+  std::mutex client_lock_;
+  debugrouter::base::WorkThreadExecutor clean_executor_;
   std::shared_ptr<UsbClient> usb_client_;
   std::shared_ptr<UsbClient> temp_usb_client_;
 
-  volatile SocketType socket_fd_ = kInvalidSocket;
+  std::atomic<SocketType> socket_fd_{kInvalidSocket};
 
  private:
   std::atomic<bool> is_running_{false};

--- a/debug_router/native/socket/win/socket_server_win.cc
+++ b/debug_router/native/socket/win/socket_server_win.cc
@@ -31,8 +31,9 @@ int32_t SocketServerWin::InitSocket() {
     return kInvalidPort;
   }
 
-  socket_fd_ = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
-  if (socket_fd_ == kInvalidSocket) {
+  const SocketType socket_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+  socket_fd_.store(socket_fd, std::memory_order_release);
+  if (socket_fd == kInvalidSocket) {
     LOGE("create socket error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "create socket error");
     return kInvalidPort;
@@ -47,7 +48,7 @@ int32_t SocketServerWin::InitSocket() {
     sockAddr.sin_family = PF_INET;
     sockAddr.sin_addr.s_addr = inet_addr("127.0.0.1");
     sockAddr.sin_port = htons(port);
-    bind_result = bind(socket_fd_, (SOCKADDR *)&sockAddr, sizeof(SOCKADDR));
+    bind_result = bind(socket_fd, (SOCKADDR *)&sockAddr, sizeof(SOCKADDR));
     if (bind_result == 0) {
       flag = true;
       break;
@@ -65,7 +66,7 @@ int32_t SocketServerWin::InitSocket() {
 
   LOGI("bind port:" << port);
 
-  if (listen(socket_fd_, kConnectionQueueMaxLength) == SOCKET_ERROR) {
+  if (listen(socket_fd, kConnectionQueueMaxLength) == SOCKET_ERROR) {
     Close();
     LOGE("listen error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "listen error");
@@ -75,16 +76,20 @@ int32_t SocketServerWin::InitSocket() {
 }
 
 void SocketServerWin::Start() {
+  SocketType socket_fd = socket_fd_.load(std::memory_order_acquire);
   int32_t port = kInvalidPort;
-  if (socket_fd_ == kInvalidSocket) {
+  if (socket_fd == kInvalidSocket) {
     port = InitSocket();
     if (port == kInvalidPort) {
       return;
     }
+    socket_fd = socket_fd_.load(std::memory_order_acquire);
   }
-  NotifyInit(0, "port:" + std::to_string(port));
-  LOGI("server socket:" << socket_fd_);
-  SocketType accept_socket_fd = accept(socket_fd_, NULL, NULL);
+  if (port != kInvalidPort) {
+    NotifyInit(0, "port:" + std::to_string(port));
+  }
+  LOGI("server socket:" << socket_fd);
+  SocketType accept_socket_fd = accept(socket_fd, NULL, NULL);
   if (accept_socket_fd == kInvalidSocket) {
     Close();
     LOGE("accept socket error:" << GetErrorMessage());

--- a/debug_router/native/test/socket_util_unittest.cc
+++ b/debug_router/native/test/socket_util_unittest.cc
@@ -2,18 +2,71 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <chrono>
 #include <cstdlib>
+#include <set>
+#include <thread>
 
 #include "debug_router/native/base/socket_guard.h"
+#include "debug_router/native/core/debug_router_core.h"
 #include "debug_router/native/core/util.h"
+#include "debug_router/native/socket/socket_server_type.h"
 #include "gtest/gtest.h"
 
 #ifndef _WIN32
-#include <sys/socket.h>
+#include <netinet/in.h>
 #include <unistd.h>
 
 #include <cerrno>
 #endif
+
+namespace {
+
+#ifndef _WIN32
+std::set<int32_t> ScanOccupiedDebugRouterPorts() {
+  std::set<int32_t> ports;
+  const int32_t end_port = debugrouter::socket_server::kStartPort +
+                           debugrouter::socket_server::kTryPortCount;
+  for (int32_t port = debugrouter::socket_server::kStartPort; port < end_port;
+       ++port) {
+    const int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (socket_fd < 0) {
+      continue;
+    }
+    int on = 1;
+    setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    errno = 0;
+    if (bind(socket_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) !=
+            0 &&
+        errno == EADDRINUSE) {
+      ports.insert(port);
+    }
+    close(socket_fd);
+  }
+  return ports;
+}
+
+template <class Predicate>
+bool WaitUntil(Predicate predicate, int timeout_ms = 2000) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  return predicate();
+}
+#endif
+
+}  // namespace
 
 TEST(SocketUtilTestSuite, TestCharToUInt32) {
   EXPECT_EQ(debugrouter::util::CharToUInt32(0xF0), (uint32_t)240);
@@ -84,5 +137,33 @@ TEST(SocketUtilTestSuite, SendNoSigPipeFailsWithoutTerminatingOnClosedPeer) {
 
   EXPECT_EQ(result, -1);
   EXPECT_EQ(errno, EPIPE);
+}
+
+TEST(SocketUtilTestSuite,
+     EnableSingleSessionDoesNotStartUsbServerUntilDebugChannelEnabled) {
+  const std::set<int32_t> ports_before = ScanOccupiedDebugRouterPorts();
+
+  auto& core = debugrouter::core::DebugRouterCore::GetInstance();
+  core.DisableDebugChannel();
+  core.EnableSingleSession(123);
+
+  EXPECT_TRUE(core.isActiveSession(123));
+  EXPECT_TRUE(WaitUntil([&ports_before]() {
+    return ScanOccupiedDebugRouterPorts() == ports_before;
+  }));
+
+  core.EnableDebugChannel();
+
+  std::set<int32_t> ports_after_enable;
+  ASSERT_TRUE(WaitUntil([&]() {
+    ports_after_enable = ScanOccupiedDebugRouterPorts();
+    return ports_after_enable.size() == ports_before.size() + 1;
+  }));
+
+  core.DisableDebugChannel();
+
+  EXPECT_TRUE(WaitUntil([&ports_before]() {
+    return ScanOccupiedDebugRouterPorts() == ports_before;
+  }));
 }
 #endif


### PR DESCRIPTION
- keep EnableSingleSession for session filtering only
- let only EnableAllSessions and EnableDebugChannel control server availability
- add a regression test for the port start/stop behavior