### PR TITLE
feat(protocol): add id field to ListSession/SessionList for request-response correlation

### DIFF
--- a/debug_router/native/processor/processor.cc
+++ b/debug_router/native/processor/processor.cc
@@ -84,7 +84,7 @@ void Processor::process(const Json::Value &root) {
       openCard(custom->AsOpenCardData()->url);
     } else if (custom->Is4ListSession()) {
       LOGI("FlushSessionList");
-      FlushSessionList();
+      FlushSessionList(custom->id_);
     } else if (custom->Is4MessageHandler()) {
       LOGI("HandleAppAction");
       HandleAppAction(custom);
@@ -132,6 +132,8 @@ std::string Processor::WrapCustomizedMessage(const std::string &type,
 
 void Processor::FlushSessionList() { sessionList(); }
 
+void Processor::FlushSessionList(int32_t id) { sessionList(id); }
+
 void Processor::SetIsReconnect(bool is_reconnect) {
   is_reconnect_ = is_reconnect;
 }
@@ -163,7 +165,7 @@ void Processor::reportError(const std::string &error) {
   }
 }
 
-void Processor::sessionList() {
+void Processor::sessionList(int32_t id) {
   if (message_handler_) {
     std::unique_ptr<protocol::CustomData4SessionList> session_list =
         std::make_unique<protocol::CustomData4SessionList>();
@@ -191,6 +193,10 @@ void Processor::sessionList() {
         protocol::RemoteDebugProtocol::CreateProtocolBody4Custom(
             protocol::kRemoteDebugProtocolBodyData4Custom4SessionList,
             client_id_, std::move(session_list));
+    // Echo back the request id so the caller can correlate the response.
+    if (id >= 0) {
+      body->AsCustom()->id_ = id;
+    }
     message_handler_->SendMessage(
         protocol::RemoteDebugProtocol::Stringify(body));
   }

--- a/debug_router/native/processor/processor.h
+++ b/debug_router/native/processor/processor.h
@@ -24,13 +24,14 @@ class Processor {
                                     const std::string &message, int mark,
                                     bool isObject = false);
   void FlushSessionList();
+  void FlushSessionList(int32_t id);
   void SetIsReconnect(bool is_reconnect);
 
  private:
   void registerDevice();
   void joinRoom();
   void reportError(const std::string &error);
-  void sessionList();
+  void sessionList(int32_t id = -1);
   void changeRoomServer(const std::string &url, const std::string &room);
   void openCard(const std::string &url);
   void processMessage(const std::string &type, int session_id,

--- a/debug_router/native/protocol/protocol.cc
+++ b/debug_router/native/protocol/protocol.cc
@@ -342,6 +342,11 @@ std::shared_ptr<RemoteDebugProtocolBody> Parse(const Json::Value &value) {
         const Json::Value &message_type = data[kKeyType];
         const Json::Value &sender = data[kKeySender];
         const Json::Value &payload = data[kKeyData];
+        const Json::Value &request_id = data[kKeyId];
+        int32_t parsed_id = -1;
+        if (request_id.isInt()) {
+          parsed_id = request_id.asInt();
+        }
         if (message_type.isString() && sender.isInt()) {
           // parsing custom data 4 stop at entry & stop lepus at entry
           if (message_type.asString().compare(
@@ -388,6 +393,7 @@ std::shared_ptr<RemoteDebugProtocolBody> Parse(const Json::Value &value) {
             custom_data->list_session_data_ = list_session;
             custom_data->type_ =
                 kRemoteDebugProtocolBodyData4Custom4ListSession;
+            custom_data->id_ = parsed_id;
             auto body = std::make_shared<RemoteDebugProtocolBody>(eventStr,
                                                                   custom_data);
             return body;

--- a/debug_router/native/protocol/protocol.h
+++ b/debug_router/native/protocol/protocol.h
@@ -316,6 +316,9 @@ struct RemoteDebugProtocolBodyData4Custom : public Stringifiable {
   bool should_stop_at_entry_;
   bool should_stop_lepus_at_entry_;
   RemoteDebugPrococolClientId client_id_;
+  // Optional request-response correlation id. When >= 0, the response
+  // echoes it back so the caller can match request to response (like CDP).
+  int32_t id_ = -1;
 
   ~RemoteDebugProtocolBodyData4Custom() = default;
 
@@ -323,6 +326,9 @@ struct RemoteDebugProtocolBodyData4Custom : public Stringifiable {
     Json::Value v(Json::objectValue);
     v[kKeyType] = type_;
     v[kKeySender] = client_id_;
+    if (id_ >= 0) {
+      v[kKeyId] = id_;
+    }
 
     if (Is4SessionList()) {
       this->session_data_list_->Stringify(v[kKeyData]);

--- a/debug_router/native/test/BUILD.gn
+++ b/debug_router/native/test/BUILD.gn
@@ -68,10 +68,12 @@ unittest_set("example_testset") {
 
 unit_test("example_unittest") {
   defines = [ "TESTING=1" ]
+  include_dirs = [ "//third_party/jsoncpp/include" ]
   sources = [
     "count_down_latch_unittest.cc",
     "debug_router_core_concurrency_unittest.cc",
     "example_source_unittest.cc",
+    "protocol_id_unittest.cc",
     "socket_server_posix_unittest.cc",
     "socket_util_unittest.cc",
   ]

--- a/debug_router/native/test/protocol_id_unittest.cc
+++ b/debug_router/native/test/protocol_id_unittest.cc
@@ -1,0 +1,98 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "debug_router/native/protocol/protocol.h"
+
+#include "gtest/gtest.h"
+#include "json/json.h"
+
+namespace debugrouter {
+namespace protocol {
+namespace {
+
+// Test that ListSession request with id is parsed correctly.
+TEST(ProtocolIdTestSuite, ParseListSessionWithId) {
+  Json::Value root;
+  root[kKeyEvent] = kRemoteDebugServerEvent4Custom;
+  Json::Value data(Json::objectValue);
+  data[kKeyType] = kRemoteDebugProtocolBodyData4Custom4ListSession;
+  data[kKeySender] = 1;
+  data[kKeyId] = 42;
+  Json::Value payload(Json::objectValue);
+  payload[kKeyClientId] = 100;
+  data[kKeyData] = payload;
+  root[kKeyData] = data;
+
+  auto body = RemoteDebugProtocol::Parse(root);
+  ASSERT_NE(body, nullptr);
+  EXPECT_TRUE(body->IsProtocolBody4Custom());
+  auto custom = body->AsCustom();
+  EXPECT_TRUE(custom->Is4ListSession());
+  EXPECT_EQ(custom->id_, 42);
+}
+
+// Test that ListSession request without id defaults to -1.
+TEST(ProtocolIdTestSuite, ParseListSessionWithoutId) {
+  Json::Value root;
+  root[kKeyEvent] = kRemoteDebugServerEvent4Custom;
+  Json::Value data(Json::objectValue);
+  data[kKeyType] = kRemoteDebugProtocolBodyData4Custom4ListSession;
+  data[kKeySender] = 1;
+  // No "id" field
+  Json::Value payload(Json::objectValue);
+  payload[kKeyClientId] = 100;
+  data[kKeyData] = payload;
+  root[kKeyData] = data;
+
+  auto body = RemoteDebugProtocol::Parse(root);
+  ASSERT_NE(body, nullptr);
+  auto custom = body->AsCustom();
+  EXPECT_TRUE(custom->Is4ListSession());
+  EXPECT_EQ(custom->id_, -1);
+}
+
+// Test that SessionList response with id serializes the id field.
+TEST(ProtocolIdTestSuite, StringifySessionListWithId) {
+  auto session_list = std::make_shared<CustomData4SessionList>();
+  auto session = std::make_shared<SessionInfo>();
+  session->session_id_ = 1;
+  session->url_ = "http://example.com";
+  session->type_ = "web";
+  session_list->list_.push_back(session);
+
+  auto body = RemoteDebugProtocol::CreateProtocolBody4Custom(
+      kRemoteDebugProtocolBodyData4Custom4SessionList, 10,
+      std::move(session_list));
+  body->AsCustom()->id_ = 42;
+
+  std::string result = RemoteDebugProtocol::Stringify(body);
+
+  Json::Reader reader;
+  Json::Value parsed;
+  ASSERT_TRUE(reader.parse(result, parsed));
+  EXPECT_EQ(parsed[kKeyData][kKeyId].asInt(), 42);
+  EXPECT_EQ(parsed[kKeyData][kKeyType].asString(),
+            kRemoteDebugProtocolBodyData4Custom4SessionList);
+}
+
+// Test that SessionList response without id does NOT emit the id field.
+TEST(ProtocolIdTestSuite, StringifySessionListWithoutId) {
+  auto session_list = std::make_shared<CustomData4SessionList>();
+
+  auto body = RemoteDebugProtocol::CreateProtocolBody4Custom(
+      kRemoteDebugProtocolBodyData4Custom4SessionList, 10,
+      std::move(session_list));
+  // id_ defaults to -1, should not be emitted.
+
+  std::string result = RemoteDebugProtocol::Stringify(body);
+
+  Json::Reader reader;
+  Json::Value parsed;
+  ASSERT_TRUE(reader.parse(result, parsed));
+  EXPECT_FALSE(parsed[kKeyData].isMember(kKeyId));
+}
+
+}  // namespace
+}  // namespace protocol
+}  // namespace debugrouter


### PR DESCRIPTION
## Summary

Add an optional `id` field to the Customized protocol messages, starting with `ListSession`/`SessionList`. When a `ListSession` request carries an `id` (integer >= 0), the `SessionList` response echoes it back so the caller can match which response belongs to which request — similar to how CDP uses `id`.

Closes #162

## Changes

| File | What |
|------|------|
| `protocol.h` | Add `int32_t id_ = -1` to `RemoteDebugProtocolBodyData4Custom`; emit in `Stringify()` when >= 0 |
| `protocol.cc` | Parse `id` from incoming Customized messages during `ListSession` handling |
| `processor.h` | Add `FlushSessionList(int32_t id)` overload |
| `processor.cc` | Thread `id` through `FlushSessionList` → `sessionList` → response body |
| `test/protocol_id_unittest.cc` | 4 new unit tests covering parse/stringify with and without id |
| `test/BUILD.gn` | Wire up the new test file |

## Design

- The `id` field lives at the Customized message `data` level (alongside `type`, `sender`, `data`).
- It is **optional and backward-compatible**: old SDKs that do not send `id` will not see it in responses. Old Connectors that receive `id` will simply ignore the unknown field.
- Only `ListSession` → `SessionList` is wired up in this PR. Other protocols (OpenCard, GetGlobalSwitch, etc.) can adopt the same pattern in follow-up PRs.

## Protocol Example

**Request (Driver → Device):**
```json
{
  "event": "Customized",
  "data": {
    "type": "ListSession",
    "id": 42,
    "data": { "client_id": 123 },
    "sender": 456
  }
}
```

**Response (Device → Driver):**
```json
{
  "event": "Customized",
  "data": {
    "type": "SessionList",
    "id": 42,
    "data": [...],
    "sender": 789,
    "signature": "..."
  }
}
```

## Testing

All 14 unit tests pass (10 existing + 4 new):
```
[  PASSED  ] 14 tests.
```
