### PR TITLE
feat(protocol): add id correlation for extension messages (GlobalSwitch, etc.)

### DIFF
--- a/debug_router/native/processor/processor.cc
+++ b/debug_router/native/processor/processor.cc
@@ -92,7 +92,9 @@ void Processor::process(const Json::Value &root) {
       LOGI("extension");
       auto ext = custom->AsExtension();
       if (ext->client_id_ == client_id_) {
+        last_request_id_ = custom->id_;
         processMessage(custom->type_, ext->session_id_, ext->message_);
+        last_request_id_ = -1;
       }
     }
   }
@@ -127,6 +129,10 @@ std::string Processor::WrapCustomizedMessage(const std::string &type,
   std::shared_ptr<protocol::RemoteDebugProtocolBody> custom =
       protocol::RemoteDebugProtocol::CreateProtocolBody4Custom(type, client_id_,
                                                                cdp_data);
+  // Echo back the request id (if any) so the caller can correlate the response.
+  if (last_request_id_ >= 0) {
+    custom->AsCustom()->id_ = last_request_id_;
+  }
   return protocol::RemoteDebugProtocol::Stringify(custom, mark);
 }
 

--- a/debug_router/native/processor/processor.h
+++ b/debug_router/native/processor/processor.h
@@ -44,6 +44,11 @@ class Processor {
   debugrouter::protocol::RemoteDebugPrococolClientId client_id_;
   std::unique_ptr<MessageHandler> message_handler_;
   bool is_reconnect_;
+  // Stores the id from the most recently received extension/CDP request so
+  // that WrapCustomizedMessage can echo it back in the response. Reset to -1
+  // after each use. This works because the request→handler→response path is
+  // synchronous within a single Process() call.
+  int32_t last_request_id_ = -1;
 
   void process(const Json::Value &root);
 };

--- a/debug_router/native/protocol/protocol.cc
+++ b/debug_router/native/protocol/protocol.cc
@@ -342,6 +342,11 @@ std::shared_ptr<RemoteDebugProtocolBody> Parse(const Json::Value &value) {
         const Json::Value &message_type = data[kKeyType];
         const Json::Value &sender = data[kKeySender];
         const Json::Value &payload = data[kKeyData];
+        const Json::Value &request_id = data[kKeyId];
+        int32_t parsed_id = -1;
+        if (request_id.isInt()) {
+          parsed_id = request_id.asInt();
+        }
         if (message_type.isString() && sender.isInt()) {
           // parsing custom data 4 stop at entry & stop lepus at entry
           if (message_type.asString().compare(
@@ -435,8 +440,10 @@ std::shared_ptr<RemoteDebugProtocolBody> Parse(const Json::Value &value) {
                 Json::FastWriter fastWriter;
                 cdp->message_ = fastWriter.write(message);
               }
-              return CreateProtocolBody4Custom(message_type.asString(),
+              auto body = CreateProtocolBody4Custom(message_type.asString(),
                                                sender.asInt(), cdp);
+              body->AsCustom()->id_ = parsed_id;
+              return body;
             }
           }
         }

--- a/debug_router/native/protocol/protocol.h
+++ b/debug_router/native/protocol/protocol.h
@@ -316,6 +316,9 @@ struct RemoteDebugProtocolBodyData4Custom : public Stringifiable {
   bool should_stop_at_entry_;
   bool should_stop_lepus_at_entry_;
   RemoteDebugPrococolClientId client_id_;
+  // Optional request-response correlation id. When >= 0, the response
+  // echoes it back so the caller can match request to response (like CDP).
+  int32_t id_ = -1;
 
   ~RemoteDebugProtocolBodyData4Custom() = default;
 
@@ -323,6 +326,9 @@ struct RemoteDebugProtocolBodyData4Custom : public Stringifiable {
     Json::Value v(Json::objectValue);
     v[kKeyType] = type_;
     v[kKeySender] = client_id_;
+    if (id_ >= 0) {
+      v[kKeyId] = id_;
+    }
 
     if (Is4SessionList()) {
       this->session_data_list_->Stringify(v[kKeyData]);

--- a/debug_router/native/test/BUILD.gn
+++ b/debug_router/native/test/BUILD.gn
@@ -68,10 +68,12 @@ unittest_set("example_testset") {
 
 unit_test("example_unittest") {
   defines = [ "TESTING=1" ]
+  include_dirs = [ "//third_party/jsoncpp/include" ]
   sources = [
     "count_down_latch_unittest.cc",
     "debug_router_core_concurrency_unittest.cc",
     "example_source_unittest.cc",
+    "extension_id_unittest.cc",
     "socket_server_posix_unittest.cc",
     "socket_util_unittest.cc",
   ]

--- a/debug_router/native/test/extension_id_unittest.cc
+++ b/debug_router/native/test/extension_id_unittest.cc
@@ -1,0 +1,104 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "debug_router/native/protocol/protocol.h"
+
+#include "gtest/gtest.h"
+#include "json/json.h"
+
+namespace debugrouter {
+namespace protocol {
+namespace {
+
+// Test that extension message (e.g. GetGlobalSwitch) with id is parsed
+// correctly via the CDP/extension fallback path.
+TEST(ExtensionIdTestSuite, ParseExtensionWithId) {
+  Json::Value root;
+  root[kKeyEvent] = kRemoteDebugServerEvent4Custom;
+  Json::Value data(Json::objectValue);
+  data[kKeyType] = "GetGlobalSwitch";
+  data[kKeySender] = 1;
+  data[kKeyId] = 77;
+  Json::Value payload(Json::objectValue);
+  payload[kKeyClientId] = 100;
+  payload[kKeySessionId] = 5;
+  payload[kKeyMessage] = "{\"global_key\":\"enable_devtool\"}";
+  data[kKeyData] = payload;
+  root[kKeyData] = data;
+
+  auto body = RemoteDebugProtocol::Parse(root);
+  ASSERT_NE(body, nullptr);
+  EXPECT_TRUE(body->IsProtocolBody4Custom());
+  auto custom = body->AsCustom();
+  EXPECT_EQ(custom->id_, 77);
+  EXPECT_EQ(custom->type_, "GetGlobalSwitch");
+}
+
+// Test that extension message without id defaults to -1.
+TEST(ExtensionIdTestSuite, ParseExtensionWithoutId) {
+  Json::Value root;
+  root[kKeyEvent] = kRemoteDebugServerEvent4Custom;
+  Json::Value data(Json::objectValue);
+  data[kKeyType] = "SetGlobalSwitch";
+  data[kKeySender] = 1;
+  // No "id" field
+  Json::Value payload(Json::objectValue);
+  payload[kKeyClientId] = 100;
+  payload[kKeySessionId] = 5;
+  payload[kKeyMessage] = "{\"global_key\":\"enable_devtool\",\"global_value\":true}";
+  data[kKeyData] = payload;
+  root[kKeyData] = data;
+
+  auto body = RemoteDebugProtocol::Parse(root);
+  ASSERT_NE(body, nullptr);
+  auto custom = body->AsCustom();
+  EXPECT_EQ(custom->id_, -1);
+}
+
+// Test that Stringify emits id for extension messages when id >= 0.
+TEST(ExtensionIdTestSuite, StringifyExtensionWithId) {
+  std::shared_ptr<CustomData4CDP> cdp_data =
+      std::make_shared<CustomData4CDP>();
+  cdp_data->client_id_ = 100;
+  cdp_data->session_id_ = 5;
+  cdp_data->message_ = "{\"global_value\":true}";
+  cdp_data->is_object_ = false;
+
+  auto body = RemoteDebugProtocol::CreateProtocolBody4Custom(
+      "GetGlobalSwitch", 1, cdp_data);
+  body->AsCustom()->id_ = 77;
+
+  std::string result = RemoteDebugProtocol::Stringify(body);
+
+  Json::Reader reader;
+  Json::Value parsed;
+  ASSERT_TRUE(reader.parse(result, parsed));
+  EXPECT_EQ(parsed[kKeyData][kKeyId].asInt(), 77);
+  EXPECT_EQ(parsed[kKeyData][kKeyType].asString(), "GetGlobalSwitch");
+}
+
+// Test that Stringify does NOT emit id when it is -1 (default).
+TEST(ExtensionIdTestSuite, StringifyExtensionWithoutId) {
+  std::shared_ptr<CustomData4CDP> cdp_data =
+      std::make_shared<CustomData4CDP>();
+  cdp_data->client_id_ = 100;
+  cdp_data->session_id_ = 5;
+  cdp_data->message_ = "{\"global_value\":true}";
+  cdp_data->is_object_ = false;
+
+  auto body = RemoteDebugProtocol::CreateProtocolBody4Custom(
+      "SetGlobalSwitch", 1, cdp_data);
+  // id_ defaults to -1, should not be emitted.
+
+  std::string result = RemoteDebugProtocol::Stringify(body);
+
+  Json::Reader reader;
+  Json::Value parsed;
+  ASSERT_TRUE(reader.parse(result, parsed));
+  EXPECT_FALSE(parsed[kKeyData].isMember(kKeyId));
+}
+
+}  // namespace
+}  // namespace protocol
+}  // namespace debugrouter


### PR DESCRIPTION
## Summary

Add request-response `id` correlation to the generic extension/CDP fallback path. This enables id-based request-response matching for **all** Customized messages that pass through the extension path, including `GetGlobalSwitch`, `SetGlobalSwitch`, and any future extension protocol types.

Companion to #162 (ListSession id) — these two PRs are independent and can be merged in parallel without conflicts.

## Mechanism

Unlike `ListSession` (handled entirely within the SDK's `Processor`), extension messages are relayed to the upper-layer SDK via `processMessage` callback, then the upper layer sends a response via `WrapCustomizedMessage`. To bridge this gap:

1. **Parse**: Extract `id` from incoming Customized messages in the CDP/extension fallback path
2. **Store**: Before calling `processMessage`, save the request `id` into `Processor::last_request_id_`. Reset to -1 after the callback returns. This is safe because the request → handler → response flow is synchronous within a single `Process()` call.
3. **Echo**: In `WrapCustomizedMessage`, if `last_request_id_ >= 0`, set it on the response body before serialization.

## Protocol Example

**Request (GetGlobalSwitch with id):**
```json
{
  "event": "Customized",
  "data": {
    "type": "GetGlobalSwitch",
    "id": 77,
    "data": { "client_id": 100, "session_id": 5, "message": {"global_key": "enable_devtool"} },
    "sender": 456
  }
}
```

**Response (echoes id back):**
```json
{
  "event": "Customized",
  "data": {
    "type": "GetGlobalSwitch",
    "id": 77,
    "data": { "client_id": 100, "session_id": 5, "message": "{\"global_value\": true}" },
    "sender": 789
  }
}
```

## Changes

| File | What |
|------|------|
| `protocol.h` | Add `int32_t id_ = -1` to `RemoteDebugProtocolBodyData4Custom`; emit in `Stringify()` when >= 0 |
| `protocol.cc` | Parse `id` from Customized messages; store in extension/CDP fallback path |
| `processor.h` | Add `int32_t last_request_id_ = -1` member |
| `processor.cc` | Set `last_request_id_` before extension callback; echo in `WrapCustomizedMessage` |
| `test/extension_id_unittest.cc` | 4 unit tests for parse/stringify with and without id |
| `test/BUILD.gn` | Wire up new test file + jsoncpp include |

## Testing

All 26 unit tests pass (22 existing + 4 new):
```
[  PASSED  ] 26 tests.
```

## Compatibility

Fully backward-compatible — `id` is optional. Old clients/SDKs that do not send `id` continue to work unchanged.
