### PR TITLE
feat(connector): correlate customized responses by id

### DIFF
--- a/debug_router_connector/src/usb/ClientAdapter.ts
+++ b/debug_router_connector/src/usb/ClientAdapter.ts
@@ -182,12 +182,21 @@ export default class ClientAdapter {
       await this.handleConnection(message);
       return;
     }
+
+    const response: any = JSON.parse(message);
+    if (
+      isTypedSocketMessage(response, SocketEvent.Customized) &&
+      this.connection &&
+      !this.connection.shouldAcceptCustomizedResponse(response)
+    ) {
+      return;
+    }
+
     this.driver.emit("usb-client-message", { id: this.id, message });
     if (this.driver.enableWebSocket) {
       this.driver.handleUsbMessage(this.id, message);
     }
 
-    const response: any = JSON.parse(message);
     const data = response.data;
     let callback = null;
     if (isTypedSocketMessage(response, SocketEvent.Customized)) {
@@ -204,7 +213,7 @@ export default class ClientAdapter {
         }
       } else {
         const cdpMessage: any = JSON.parse(data.data.message);
-        if (cdpMessage?.id && this.connection) {
+        if (cdpMessage?.id !== undefined && this.connection) {
           callback = this.connection.matchPendingRequest(
             cdpMessage.id.toString(),
           );

--- a/debug_router_connector/src/usb/Connection.ts
+++ b/debug_router_connector/src/usb/Connection.ts
@@ -9,6 +9,7 @@ import {
   RequireMessageType,
   ResponseMessageType,
 } from "../utils/type";
+import { CustomizedMessageCorrelation } from "../utils/customized_message_correlation";
 
 export interface PendingRequestResolvers {
   resolve: (data: ResponseMessageType) => void;
@@ -17,6 +18,7 @@ export interface PendingRequestResolvers {
 
 export abstract class Connection {
   private readonly events = new EventEmitter();
+  private readonly messageCorrelation = new CustomizedMessageCorrelation();
   protected pendingRequests: Map<string, PendingRequestResolvers> = new Map();
   abstract close(): void;
   abstract send(data: any): void;
@@ -31,6 +33,14 @@ export abstract class Connection {
 
   handleSessionList(sessionList: any) {
     this.events.emit("SessionList", sessionList);
+  }
+
+  shouldAcceptCustomizedResponse(response: any): boolean {
+    return this.messageCorrelation.shouldAcceptResponse(response);
+  }
+
+  protected prepareCustomizedRequest<T>(message: T): T {
+    return this.messageCorrelation.prepareRequest(message);
   }
 
   on(event: string, callback: EventHandler) {

--- a/debug_router_connector/src/usb/USBConnection.ts
+++ b/debug_router_connector/src/usb/USBConnection.ts
@@ -45,10 +45,11 @@ export class USBConnection extends Connection {
 
   send(data: any): void {
     if (this.socket.writable) {
+      const message = this.prepareCustomizedRequest(data);
       if (process.env.PrintAllUSBMessage === "enable") {
-        defaultLogger.info("[Send]:" + JSON.stringify(data));
+        defaultLogger.info("[Send]:" + JSON.stringify(message));
       }
-      this.socket.write(packMessage(data));
+      this.socket.write(packMessage(message));
     }
   }
   sendExpectResponse(

--- a/debug_router_connector/src/utils/customized_message_correlation.ts
+++ b/debug_router_connector/src/utils/customized_message_correlation.ts
@@ -1,0 +1,176 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { randomInt } from "crypto";
+
+const MIN_REQUEST_ID = 1;
+const MAX_REQUEST_ID = 0x7fffffff;
+const OUTER_ID_REQUEST_RESPONSE_TYPES = new Map([
+  ["ListSession", "SessionList"],
+]);
+const OUTER_ID_RESPONSE_TYPES = new Set(
+  OUTER_ID_REQUEST_RESPONSE_TYPES.values(),
+);
+const INNER_MESSAGE_ID_TYPES = new Set(["CDP", "App"]);
+
+function isCustomizedMessage(message: any): boolean {
+  return message?.event === "Customized";
+}
+
+function isValidRequestId(id: unknown): id is number {
+  return (
+    typeof id === "number" &&
+    Number.isInteger(id) &&
+    id >= 0 &&
+    id <= MAX_REQUEST_ID
+  );
+}
+
+function parseInnerMessage(message: any): any {
+  const innerMessage = message?.data?.data?.message;
+  if (typeof innerMessage !== "string") {
+    return innerMessage;
+  }
+
+  try {
+    return JSON.parse(innerMessage);
+  } catch (_) {
+    return undefined;
+  }
+}
+
+/**
+ * Correlates request/response messages sent through one transport connection.
+ *
+ * ListSession uses Customized.data.id. CDP and App keep using the id in their
+ * inner message payload, matching their existing protocol format.
+ */
+export class CustomizedMessageCorrelation {
+  private readonly pendingRequestIds = new Map<string, Set<number>>();
+
+  prepareRequest<T>(message: T): T {
+    if (!isCustomizedMessage(message)) {
+      return message;
+    }
+
+    const type = (message as any).data.type;
+    const responseType = OUTER_ID_REQUEST_RESPONSE_TYPES.get(type);
+    if (responseType) {
+      return this.prepareOuterIdRequest(message, responseType);
+    }
+
+    if (INNER_MESSAGE_ID_TYPES.has(type)) {
+      const innerMessage = parseInnerMessage(message);
+      if (
+        typeof innerMessage?.method === "string" &&
+        isValidRequestId(innerMessage.id)
+      ) {
+        this.addPendingRequest(type, innerMessage.id);
+      }
+    }
+
+    return message;
+  }
+
+  shouldAcceptResponse(message: any): boolean {
+    if (!isCustomizedMessage(message)) {
+      return true;
+    }
+
+    const type = message.data.type;
+    if (OUTER_ID_RESPONSE_TYPES.has(type)) {
+      return this.shouldAcceptOuterIdResponse(message, type);
+    }
+
+    if (INNER_MESSAGE_ID_TYPES.has(type)) {
+      const responseId = parseInnerMessage(message)?.id;
+      // CDP/App messages without id are events rather than correlated
+      // responses, so preserve their existing delivery behavior.
+      if (responseId === undefined) {
+        return true;
+      }
+      return (
+        isValidRequestId(responseId) &&
+        this.consumePendingRequest(type, responseId)
+      );
+    }
+
+    return true;
+  }
+
+  private prepareOuterIdRequest<T>(message: T, responseType: string): T {
+    const currentId = (message as any).data.id;
+    const id = isValidRequestId(currentId)
+      ? currentId
+      : this.createRequestId(responseType);
+    this.addPendingRequest(responseType, id);
+
+    if (id === currentId) {
+      return message;
+    }
+
+    return {
+      ...(message as any),
+      data: {
+        ...(message as any).data,
+        id,
+      },
+    } as T;
+  }
+
+  private shouldAcceptOuterIdResponse(
+    message: any,
+    responseType: string,
+  ): boolean {
+    const responseId = message.data.id;
+    if (responseId === undefined) {
+      // An old SDK cannot echo the id. Always preserve that compatibility,
+      // including the existing unsolicited SessionList event behavior.
+      this.consumeOldestPendingRequest(responseType);
+      return true;
+    }
+
+    return (
+      isValidRequestId(responseId) &&
+      this.consumePendingRequest(responseType, responseId)
+    );
+  }
+
+  private addPendingRequest(type: string, id: number): void {
+    let ids = this.pendingRequestIds.get(type);
+    if (!ids) {
+      ids = new Set<number>();
+      this.pendingRequestIds.set(type, ids);
+    }
+    ids.add(id);
+  }
+
+  private consumePendingRequest(type: string, id: number): boolean {
+    const ids = this.pendingRequestIds.get(type);
+    if (!ids?.delete(id)) {
+      return false;
+    }
+    if (ids.size === 0) {
+      this.pendingRequestIds.delete(type);
+    }
+    return true;
+  }
+
+  private consumeOldestPendingRequest(type: string): void {
+    const ids = this.pendingRequestIds.get(type);
+    const firstPendingId = ids?.values().next().value;
+    if (firstPendingId !== undefined) {
+      this.consumePendingRequest(type, firstPendingId);
+    }
+  }
+
+  private createRequestId(responseType: string): number {
+    const pendingIds = this.pendingRequestIds.get(responseType);
+    let id: number;
+    do {
+      id = randomInt(MIN_REQUEST_ID, MAX_REQUEST_ID + 1);
+    } while (pendingIds?.has(id));
+    return id;
+  }
+}

--- a/debug_router_connector/src/utils/type.ts
+++ b/debug_router_connector/src/utils/type.ts
@@ -134,6 +134,7 @@ export type SessionListType = {
   type: CustomizedEventType.SessionList;
   data: Array<SessionInfoType>;
   sender: number;
+  id?: number;
 };
 
 export type CDPResponseType = {
@@ -171,6 +172,7 @@ export type CustomizeMessageType = {
   event: "Customized";
   data: {
     type: string;
+    id?: number;
     data: {
       client_id: number;
       session_id: number;

--- a/debug_router_connector/src/websocket/WebSocketConnection.ts
+++ b/debug_router_connector/src/websocket/WebSocketConnection.ts
@@ -14,6 +14,7 @@ import {
   ResponseMessageType,
   SocketEvent,
 } from "../utils/type";
+import { CustomizedMessageCorrelation } from "../utils/customized_message_correlation";
 
 export type WebSocketClientInfo = {
   id: number;
@@ -28,6 +29,7 @@ export type WebSocketClientInfo = {
 };
 
 export class WebSocketClient extends Client {
+  private readonly messageCorrelation = new CustomizedMessageCorrelation();
   private pendingRequests: Map<
     string,
     { resolve: (message: string) => void; reject: (err: Error) => void }
@@ -51,7 +53,21 @@ export class WebSocketClient extends Client {
   }
 
   sendMessage(message: string) {
-    this.socket.send(message);
+    let outgoingMessage = message;
+    try {
+      const parsedMessage = JSON.parse(message);
+      const preparedMessage = this.messageCorrelation.prepareRequest(
+        parsedMessage,
+      );
+      if (preparedMessage !== parsedMessage) {
+        outgoingMessage = JSON.stringify(preparedMessage);
+      }
+    } catch (error: any) {
+      defaultLogger.debug(
+        "webSocketClient sendMessage parse error:" + error?.message,
+      );
+    }
+    this.socket.send(outgoingMessage);
   }
 
   close() {
@@ -129,6 +145,12 @@ export class WebSocketClient extends Client {
       defaultLogger.debug("handleMessage received data with type 'string'");
     }
     const message = JSON.parse(dataString);
+    if (
+      this.type() !== "Driver" &&
+      !this.messageCorrelation.shouldAcceptResponse(message)
+    ) {
+      return;
+    }
     if (this.type() === "Driver") {
       this.server.emitEvent("ws-web-message", this.clientId(), dataString);
     } else {
@@ -144,7 +166,7 @@ export class WebSocketClient extends Client {
         const payload = message?.data?.data?.message;
         if (typeof payload === "string") {
           const cdpMessage = JSON.parse(payload);
-          if (cdpMessage?.id) {
+          if (cdpMessage?.id !== undefined) {
             const key = cdpMessage.id.toString();
             const pending = this.pendingRequests.get(key);
             if (pending) {
@@ -241,7 +263,7 @@ export class WebSocketClient extends Client {
         },
       });
 
-      this.socket.send(JSON.stringify(msg));
+      this.sendMessage(JSON.stringify(msg));
     });
   }
 }

--- a/test/e2e_test/connector_test/debug_router_connector_auto_test.js
+++ b/test/e2e_test/connector_test/debug_router_connector_auto_test.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const childProcess = require("child_process");
+const { EventEmitter } = require("events");
 const fs = require("fs");
 const net = require("net");
 const os = require("os");
@@ -7,6 +8,7 @@ const path = require("path");
 
 const {
   DebugRouterConnector,
+  WebSocketClient,
 } = require("@lynx-js/debug-router-connector");
 
 const DEFAULT_ANDROID_ACTIVITY =
@@ -199,6 +201,7 @@ async function startFakeDebugRouterAppServer() {
   const sockets = new Set();
   const receivedMessages = [];
   const appName = "connector-auto-test-app";
+  let listSessionRequestCount = 0;
 
   const server = net.createServer((socket) => {
     sockets.add(socket);
@@ -226,27 +229,85 @@ async function startFakeDebugRouterAppServer() {
         }
 
         if (message.event === "Customized") {
-          const requestMessage = message.data?.data?.message ?? {};
-          socket.write(
-            packMessage({
+          if (message.data?.type === "ListSession") {
+            listSessionRequestCount++;
+            const requestId = message.data.id;
+            const sessionListResponse = (id, sessionId) => ({
               event: "Customized",
               data: {
-                type: message.data?.type ?? "App",
-                data: {
-                  client_id: message.data?.data?.client_id ?? -1,
-                  session_id: message.data?.data?.session_id ?? -1,
-                  message: JSON.stringify({
-                    id: requestMessage.id,
-                    result: {
-                      ok: true,
-                      method: requestMessage.method,
-                      params: requestMessage.params,
-                    },
-                  }),
-                },
+                type: "SessionList",
+                data: [
+                  {
+                    session_id: sessionId,
+                    type: "lynx",
+                    url: `https://example.com/${sessionId}`,
+                  },
+                ],
                 sender: -1,
+                ...(id !== undefined ? { id } : {}),
               },
-            }),
+            });
+
+            if (listSessionRequestCount === 1) {
+              socket.write(packMessage(sessionListResponse(-1, -1)));
+              socket.write(packMessage(sessionListResponse(requestId + 1, -2)));
+              socket.write(packMessage(sessionListResponse(requestId, 1)));
+              socket.write(packMessage(sessionListResponse(-1, -3)));
+              socket.write(packMessage(sessionListResponse(requestId + 2, -4)));
+            } else if (listSessionRequestCount === 2) {
+              // Simulate an old SDK that cannot echo the request id.
+              socket.write(packMessage(sessionListResponse(undefined, 2)));
+            } else {
+              socket.write(packMessage(sessionListResponse(requestId, 3)));
+            }
+            return;
+          }
+
+          const requestMessage = message.data?.data?.message ?? {};
+          const customizedResponse = (id) => ({
+            event: "Customized",
+            data: {
+              type: message.data?.type ?? "App",
+              data: {
+                client_id: message.data?.data?.client_id ?? -1,
+                session_id: message.data?.data?.session_id ?? -1,
+                message: JSON.stringify({
+                  id,
+                  result: {
+                    ok: true,
+                    method: requestMessage.method,
+                    params: requestMessage.params,
+                  },
+                }),
+              },
+              sender: -1,
+            },
+          });
+          socket.write(
+            packMessage(customizedResponse(requestMessage.id + 1)),
+          );
+          if (message.data?.type === "CDP") {
+            socket.write(
+              packMessage({
+                event: "Customized",
+                data: {
+                  type: "CDP",
+                  data: {
+                    client_id: -1,
+                    session_id: message.data?.data?.session_id ?? -1,
+                    message: JSON.stringify({
+                      method: "Runtime.consoleAPICalled",
+                      params: { source: "connector-auto-test" },
+                    }),
+                  },
+                  sender: -1,
+                },
+              }),
+            );
+          }
+          socket.write(packMessage(customizedResponse(requestMessage.id)));
+          socket.write(
+            packMessage(customizedResponse(requestMessage.id + 2)),
           );
         }
       }),
@@ -361,6 +422,92 @@ async function runEmptyDiscoveryCheck() {
   }
 }
 
+function createFakeWebSocket() {
+  const socket = new EventEmitter();
+  socket.sentMessages = [];
+  socket.send = (message) => socket.sentMessages.push(message);
+  socket.close = () => {};
+  return socket;
+}
+
+async function runWebSocketCorrelationCheck() {
+  logStep("checking WebSocket request and response correlation");
+  const messagesToApp = [];
+  const messagesToWeb = [];
+  const server = {
+    emitEvent: () => {},
+    handleDisconnect: () => {},
+    sendMessageToApp: (id, message) => messagesToApp.push({ id, message }),
+    sendMessageToWeb: (message) => messagesToWeb.push(message),
+  };
+  const clientInfo = (id, type) => ({ id, type, raw_info: {} });
+
+  const driverSocket = createFakeWebSocket();
+  new WebSocketClient(server, clientInfo(1, "Driver"), driverSocket);
+  const driverRequest = {
+    event: "Customized",
+    data: {
+      type: "CDP",
+      data: {
+        client_id: 42,
+        session_id: 1,
+        message: { id: 1001, method: "Runtime.enable", params: {} },
+      },
+      sender: 1,
+    },
+  };
+  driverSocket.emit("message", Buffer.from(JSON.stringify(driverRequest)));
+  assert.strictEqual(messagesToApp.length, 1);
+  assert.strictEqual(messagesToApp[0].id, 42);
+
+  const runtimeSocket = createFakeWebSocket();
+  const runtimeClient = new WebSocketClient(
+    server,
+    clientInfo(2, "runtime"),
+    runtimeSocket,
+  );
+  runtimeClient.sendMessage(JSON.stringify(driverRequest));
+
+  const runtimeResponse = (message) =>
+    Buffer.from(
+      JSON.stringify({
+        event: "Customized",
+        data: {
+          type: "CDP",
+          data: {
+            client_id: 42,
+            session_id: 1,
+            message: JSON.stringify(message),
+          },
+          sender: 1,
+        },
+      }),
+    );
+
+  runtimeSocket.emit("message", runtimeResponse({ id: 1002, result: {} }));
+  runtimeSocket.emit(
+    "message",
+    runtimeResponse({
+      method: "Runtime.consoleAPICalled",
+      params: { source: "websocket-correlation-test" },
+    }),
+  );
+  runtimeSocket.emit("message", runtimeResponse({ id: 1001, result: {} }));
+  runtimeSocket.emit("message", runtimeResponse({ id: 1003, result: {} }));
+
+  assert.strictEqual(messagesToWeb.length, 2);
+  const forwardedMessages = messagesToWeb.map((message) =>
+    JSON.parse(JSON.parse(message).data.data.message),
+  );
+  assert.deepStrictEqual(forwardedMessages, [
+    {
+      method: "Runtime.consoleAPICalled",
+      params: { source: "websocket-correlation-test" },
+    },
+    { id: 1001, result: {} },
+  ]);
+}
+
 async function runFakeNetworkCheck() {
   logStep("checking no-device end-to-end flow with a local NetworkDevice");
   const fakeApp = await startFakeDebugRouterAppServer();
@@ -406,6 +553,24 @@ async function runFakeNetworkCheck() {
     assert.strictEqual(clients[0].info.query.app, fakeApp.appName);
     assert.strictEqual(driver.getAllUsbClients().length, 1);
 
+    const correlatedResponseIds = [];
+    const handleUsbClientMessage = ({ message }) => {
+      const responseMessage = JSON.parse(message);
+      if (
+        responseMessage.event !== "Customized" ||
+        !["App", "CDP"].includes(responseMessage.data?.type)
+      ) {
+        return;
+      }
+      const innerMessage = JSON.parse(responseMessage.data.data.message);
+      if (innerMessage.id !== undefined) {
+        correlatedResponseIds.push(
+          `${responseMessage.data.type}:${innerMessage.id}`,
+        );
+      }
+    };
+    driver.on("usb-client-message", handleUsbClientMessage);
+
     const nonce = `nonce-${Date.now()}`;
     const response = await withTimeout(
       clients[0].sendClientMessage("ConnectorAutoTest.Ping", { nonce }),
@@ -418,6 +583,93 @@ async function runFakeNetworkCheck() {
       method: "ConnectorAutoTest.Ping",
       params: { nonce },
     });
+
+    const cdpEvents = [];
+    const handleCdpEvent = (params) => cdpEvents.push(params);
+    clients[0].on("Runtime.consoleAPICalled", handleCdpEvent);
+    const cdpResponse = await withTimeout(
+      clients[0].sendCustomizedMessage("Runtime.enable", {}, 1, "CDP"),
+      3000,
+      "fake CDP response",
+    );
+    const cdpPayload = JSON.parse(cdpResponse);
+    assert.deepStrictEqual(cdpPayload.result, {
+      ok: true,
+      method: "Runtime.enable",
+      params: {},
+    });
+    await waitFor(
+      () => cdpEvents.length === 1,
+      1000,
+      "CDP event without id",
+    );
+    assert.deepStrictEqual(cdpEvents[0], { source: "connector-auto-test" });
+
+    const appRequest = fakeApp.receivedMessages.find(
+      (msg) => msg.data?.type === "App",
+    );
+    const cdpRequest = fakeApp.receivedMessages.find(
+      (msg) => msg.data?.type === "CDP",
+    );
+    assert.deepStrictEqual(correlatedResponseIds, [
+      `App:${appRequest.data.data.message.id}`,
+      `CDP:${cdpRequest.data.data.message.id}`,
+    ]);
+    clients[0].off("Runtime.consoleAPICalled", handleCdpEvent);
+
+    const sessionLists = [];
+    const handleSessionList = (sessions) => sessionLists.push(sessions);
+    clients[0].on("SessionList", handleSessionList);
+
+    const createListSessionRequest = () => ({
+      event: "Customized",
+      data: {
+        type: "ListSession",
+        data: { client_id: -1 },
+        sender: 0,
+      },
+    });
+
+    clients[0].sendMessage(createListSessionRequest());
+    await waitFor(
+      () => sessionLists.length === 1,
+      1000,
+      "correlated SessionList response",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.strictEqual(sessionLists.length, 1);
+    assert.strictEqual(sessionLists[0][0].session_id, 1);
+
+    const firstListSessionRequest = fakeApp.receivedMessages.find(
+      (msg) => msg.data?.type === "ListSession",
+    );
+    assert(Number.isInteger(firstListSessionRequest?.data?.id));
+    assert(firstListSessionRequest.data.id >= 0);
+
+    clients[0].sendMessage(createListSessionRequest());
+    await waitFor(
+      () => sessionLists.length === 2,
+      1000,
+      "legacy SessionList response without id",
+    );
+    assert.strictEqual(sessionLists[1][0].session_id, 2);
+
+    const explicitRequestId = 424242;
+    const requestWithId = createListSessionRequest();
+    requestWithId.data.id = explicitRequestId;
+    clients[0].sendMessage(requestWithId);
+    await waitFor(
+      () => sessionLists.length === 3,
+      1000,
+      "SessionList response with caller-provided id",
+    );
+    assert.strictEqual(sessionLists[2][0].session_id, 3);
+    const listSessionRequests = fakeApp.receivedMessages.filter(
+      (msg) => msg.data?.type === "ListSession",
+    );
+    assert.strictEqual(listSessionRequests[2].data.id, explicitRequestId);
+    clients[0].off("SessionList", handleSessionList);
+    driver.off("usb-client-message", handleUsbClientMessage);
 
     await waitFor(
       () => fakeApp.receivedMessages.some((msg) => msg.event === "Customized"),
@@ -608,6 +860,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.mode === "no-device") {
     await runEmptyDiscoveryCheck();
+    await runWebSocketCorrelationCheck();
     await runFakeNetworkCheck();
   } else {
     await runRealDeviceScenario(args);


### PR DESCRIPTION
## Summary

- add a reusable customized-message correlation tracker
- send ListSession with an id and only accept SessionList responses without an id (legacy SDK) or with the matching id
- ignore -1 and mismatched response ids; apply the same matching to CDP/App nested ids while preserving id-less events
- cover USB/TCP and WebSocket paths

Connector counterpart to #163.

## Testing

- `cd debug_router_connector && npm run build`
- `cd test/e2e_test/connector_test && npm test`