### PR TITLE
[BugFix] Preserve connector ownership during USB handshake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ on:
       - main
 
 jobs:
+  debug-router-connector-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Run debug-router-connector tests
+        working-directory: debug_router_connector
+        run: npm ci && npm test
+
   static-check:
     runs-on: lynx-ubuntu-22.04-medium
     steps:

--- a/debug_router_connector/package.json
+++ b/debug_router_connector/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node bin/driver.js start",
     "build": "rm -rf dist && bash ./scripts/build.sh",
+    "test": "npm run build && node --test test/*.test.js",
     "types": "rm -rf lib && rm -rf typings && tsc -p tsconfig.prod.json",
     "format": "prettier --write ."
   },

--- a/debug_router_connector/src/connector/DebugRouterConnector.ts
+++ b/debug_router_connector/src/connector/DebugRouterConnector.ts
@@ -335,7 +335,7 @@ export class DebugRouterConnector {
     defaultLogger.info("disableAllClients");
     // close usb autoConnect
     this.devices.forEach((device) => {
-      device.stopWatchClient();
+      device.closeClientController();
     });
     this.getAllAppClients().forEach((client) => {
       client.close();

--- a/debug_router_connector/src/device/BaseDevice.ts
+++ b/debug_router_connector/src/device/BaseDevice.ts
@@ -55,8 +55,17 @@ export abstract class BaseDevice {
       os: this.info.os,
       title: this.info.title,
     });
-    this.clientController?.stopWatchClient();
-    this.clientController = new ClientController(this.driver, this);
+    if (!this.connected) {
+      return;
+    }
+    if (
+      this.clientController &&
+      !this.clientController.matchesPorts(this.ports)
+    ) {
+      this.clientController.close();
+      this.clientController = undefined;
+    }
+    this.clientController ??= new ClientController(this.driver, this);
     this.clientController.startWatchClient();
   }
 
@@ -71,10 +80,13 @@ export abstract class BaseDevice {
     }
   }
 
+  closeClientController() {
+    this.clientController?.close();
+    this.clientController = undefined;
+  }
+
   disConnect() {
     this.connected = false;
-    if (this.clientController) {
-      this.clientController.close();
-    }
+    this.closeClientController();
   }
 }

--- a/debug_router_connector/src/usb/ClientAdapter.ts
+++ b/debug_router_connector/src/usb/ClientAdapter.ts
@@ -46,6 +46,7 @@ export default class ClientAdapter {
   protected from?: number;
   protected id: number = 0;
   private connectionAttemptId?: string;
+  private state: "idle" | "active" | "closed" = "idle";
   constructor(
     protected driver: DebugRouterConnector,
     protected listener: ClientEventsListener | null,
@@ -57,6 +58,9 @@ export default class ClientAdapter {
   ) {}
 
   protected handleData(client: net.Socket, data: Buffer) {
+    if (this.state === "closed") {
+      return;
+    }
     try {
       this.handleUnpackMessage(data);
     } catch (error: any) {
@@ -72,18 +76,32 @@ export default class ClientAdapter {
   }
 
   protected handleOff(client: net.Socket) {
+    this.closeAttempt(client, true);
+  }
+
+  private closeAttempt(client: net.Socket, notifyListener: boolean) {
+    if (this.state === "closed") {
+      return;
+    }
+    const wasActive = this.state === "active";
+    this.state = "closed";
     this.isConnected = false;
     client.destroy();
-    this.driver.traceRecorder?.recordSocketDisconnected(
-      this.device_id,
-      this.port,
-      {
-        device: this.device,
-        os: this.type,
-      },
-      this.connectionAttemptId,
-    );
+    if (wasActive) {
+      this.driver.traceRecorder?.recordSocketDisconnected(
+        this.device_id,
+        this.port,
+        {
+          device: this.device,
+          os: this.type,
+        },
+        this.connectionAttemptId,
+      );
+    }
     this.connectionAttemptId = undefined;
+    if (!notifyListener) {
+      return;
+    }
     if (this.listener === null) {
       defaultLogger.debug("handleOff: this.listener == null");
       return;
@@ -151,6 +169,9 @@ export default class ClientAdapter {
   }
 
   onConnect(): void {
+    if (this.state !== "active") {
+      return;
+    }
     const initialize: InitializeMessageType = {
       event: "Initialize",
       data: -1,
@@ -163,13 +184,16 @@ export default class ClientAdapter {
         os: this.type,
       },
     );
+    if (!this.tcpClient.writable || this.tcpClient.destroyed) {
+      this.handleOff(this.tcpClient);
+      return;
+    }
     try {
-      if (this.tcpClient.writable && !this.tcpClient.destroyed) {
-        defaultLogger.debug("send Initialize:" + this.port);
-        this.tcpClient.write(packMessage(initialize));
-      }
+      defaultLogger.debug("send Initialize:" + this.port);
+      this.tcpClient.write(packMessage(initialize));
     } catch (err) {
       defaultLogger.debug("send Initialize error:" + JSON.stringify(err));
+      this.handleOff(this.tcpClient);
     }
   }
 
@@ -294,11 +318,16 @@ export default class ClientAdapter {
   }
 
   connect(): void {
-    if (this.isConnected || this.tcpClient.connecting) return;
+    if (this.state !== "idle") return;
+    this.state = "active";
     const platform = this.type;
     if (platform === "iOS") {
       getTunnel(this.port, { udid: this.device_id })
         .then((tunnel: net.Socket) => {
+          if (this.state !== "active") {
+            tunnel.destroy();
+            return;
+          }
           this.tcpClient = tunnel;
           this.tcpClient.on("data", (data: Buffer) => {
             this.handleData(this.tcpClient, data);
@@ -327,6 +356,7 @@ export default class ClientAdapter {
             msg: msg,
             stage: "client",
           });
+          this.closeAttempt(this.tcpClient, true);
         });
     } else {
       try {
@@ -367,6 +397,7 @@ export default class ClientAdapter {
           msg: msg,
           stage: "client",
         });
+        this.closeAttempt(this.tcpClient, true);
       }
     }
   }
@@ -374,8 +405,16 @@ export default class ClientAdapter {
   public destroy() {
     defaultLogger.debug("ClientAdapter destroy");
     this.listener = null;
-    this.tcpClient.destroy();
+    this.closeAttempt(this.tcpClient, false);
     this.buffer = null;
     this.connection = null;
+  }
+
+  public isAttemptActive(): boolean {
+    return this.state === "active";
+  }
+
+  public isClosed(): boolean {
+    return this.state === "closed";
   }
 }

--- a/debug_router_connector/src/usb/ClientController.ts
+++ b/debug_router_connector/src/usb/ClientController.ts
@@ -13,9 +13,11 @@ import { defaultLogger } from "../utils/logger";
 
 export class ClientController implements ClientEventsListener {
   private timer: NodeJS.Timeout | undefined;
+  private closed: boolean = false;
   private sockets: Map<number, ClientAdapter> = new Map();
   private ports: Map<number, boolean> = new Map();
   private clientInfos: Map<number, number> = new Map();
+  private readonly portSnapshot: Set<number>;
   connections: Map<number, UsbClient> = new Map();
   driver: DebugRouterConnector;
   device: BaseDevice;
@@ -23,20 +25,20 @@ export class ClientController implements ClientEventsListener {
   constructor(driver: DebugRouterConnector, serverDevice: BaseDevice) {
     this.driver = driver;
     this.device = serverDevice;
+    this.portSnapshot = new Set(this.device.ports);
 
-    this.device.ports.map((port) => {
-      const connectAdapter = new ClientAdapter(
-        this.driver,
-        this,
-        port,
-        this.device.info.title,
-        this.device.info.serial,
-        this.device.info.os,
-        this.device.getHost(),
-      );
-      this.sockets.set(port, connectAdapter);
+    this.portSnapshot.forEach((port) => {
+      this.sockets.set(port, this.createAdapter(port));
       this.ports.set(port, false);
     });
+  }
+
+  matchesPorts(ports: number[]): boolean {
+    const currentPorts = new Set(ports);
+    return (
+      currentPorts.size === this.portSnapshot.size &&
+      [...currentPorts].every((port) => this.portSnapshot.has(port))
+    );
   }
 
   onConnectionDeleted(id: number): void {
@@ -56,6 +58,10 @@ export class ClientController implements ClientEventsListener {
     port: number,
     query: ClientQuery,
   ): number {
+    if (this.closed) {
+      connection.close();
+      return 0;
+    }
     defaultLogger.debug(
       "addConnection port: " + port + " info: " + JSON.stringify(query),
     );
@@ -86,22 +92,21 @@ export class ClientController implements ClientEventsListener {
 
   private removeConnection(id: number) {
     const client = this.connections.get(id);
-    if (client) {
-      this.driver.traceRecorder?.recordUsbClientDisconnected(client);
-      this.connections.delete(id);
+    if (!client) {
+      return;
     }
+
+    this.driver.traceRecorder?.recordUsbClientDisconnected(client);
+    this.connections.delete(id);
     const port = this.clientInfos.get(id);
-    if (port) {
+    if (port !== undefined) {
       this.ports.set(port, false);
       this.clientInfos.delete(id);
     }
     this.driver.unregiserUsbClient(id);
   }
 
-  private createAdapter(
-    connectAdapter: ClientAdapter | undefined,
-    port: number,
-  ): ClientAdapter {
+  private createAdapter(port: number): ClientAdapter {
     return new ClientAdapter(
       this.driver,
       this,
@@ -114,36 +119,46 @@ export class ClientController implements ClientEventsListener {
   }
 
   private watchClient() {
+    if (this.closed) {
+      return;
+    }
     for (const port of this.ports.keys()) {
       if (!this.ports.get(port)) {
-        const connectAdapter = this.sockets.get(port);
-        const newAdapter = this.createAdapter(connectAdapter, port);
-        connectAdapter?.destroy();
-        if (newAdapter === null) {
-          defaultLogger.debug("newAdapter === null:" + port);
-          return;
+        let connectAdapter = this.sockets.get(port);
+        if (connectAdapter?.isAttemptActive()) {
+          continue;
         }
-        this.sockets.set(port, newAdapter);
+        if (!connectAdapter || connectAdapter.isClosed()) {
+          connectAdapter?.destroy();
+          connectAdapter = this.createAdapter(port);
+          this.sockets.set(port, connectAdapter);
+        }
         defaultLogger.debug("watchClient:connect:" + port);
-        newAdapter.connect();
+        connectAdapter.connect();
       }
     }
   }
 
   startWatchClient(): void {
+    if (this.closed) {
+      return;
+    }
     this.watchClient();
     if (process.env.DriverAutoFindClientsEnv === "false") {
       defaultLogger.warn("AutoFinding new client is closed for debug");
       return;
     }
-    this.timer = setInterval(() => {
-      this.watchClient();
-    }, this.driver.usbConnectOpt.retryTime);
+    if (!this.timer) {
+      this.timer = setInterval(() => {
+        this.watchClient();
+      }, this.driver.usbConnectOpt.retryTime);
+    }
   }
 
   stopWatchClient(): void {
     if (this.timer) {
       clearInterval(this.timer);
+      this.timer = undefined;
     }
   }
 
@@ -155,7 +170,15 @@ export class ClientController implements ClientEventsListener {
   }
 
   close() {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
     this.stopWatchClient();
     this.closeAllConnection();
+    this.sockets.forEach((adapter) => adapter.destroy());
+    this.sockets.clear();
+    this.clientInfos.clear();
+    this.ports.clear();
   }
 }

--- a/debug_router_connector/test/client_ownership.test.js
+++ b/debug_router_connector/test/client_ownership.test.js
@@ -1,0 +1,417 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("node:assert/strict");
+const net = require("node:net");
+const { afterEach, test } = require("node:test");
+
+const { BaseDevice } = require("../dist/cjs/src/device/BaseDevice.js");
+const {
+  DebugRouterConnector,
+} = require("../dist/cjs/src/connector/DebugRouterConnector.js");
+const ClientAdapter = require("../dist/cjs/src/usb/ClientAdapter.js").default;
+const { ClientController } = require("../dist/cjs/src/usb/ClientController.js");
+const usbmux = require("../dist/cjs/third_party/usbmux/lib/usbmux.js");
+
+const originalAutoFind = process.env.DriverAutoFindClientsEnv;
+const originalAdapterConnect = ClientAdapter.prototype.connect;
+const originalGetTunnel = usbmux.getTunnel;
+const originalSocket = net.Socket;
+
+afterEach(() => {
+  ClientAdapter.prototype.connect = originalAdapterConnect;
+  net.Socket = originalSocket;
+  usbmux.getTunnel = originalGetTunnel;
+  if (originalAutoFind === undefined) {
+    delete process.env.DriverAutoFindClientsEnv;
+  } else {
+    process.env.DriverAutoFindClientsEnv = originalAutoFind;
+  }
+});
+
+test("reuses an idle/active attempt and replaces it only after close", () => {
+  const driver = createDriver();
+  const controller = new ClientController(driver, createDevice());
+  const adapter = createAdapter("idle");
+  const replacement = createAdapter("idle");
+  let createCount = 0;
+
+  controller.sockets = new Map([[8901, adapter]]);
+  controller.ports = new Map([[8901, false]]);
+  controller.createAdapter = () => {
+    createCount++;
+    return replacement;
+  };
+
+  controller.watchClient();
+  assert.equal(createCount, 0);
+  assert.equal(adapter.connectCount, 1);
+  assert.equal(adapter.destroyCount, 0);
+  controller.watchClient();
+  assert.equal(createCount, 0);
+  assert.equal(adapter.destroyCount, 0);
+
+  adapter.setState("closed");
+  controller.watchClient();
+  controller.watchClient();
+  assert.equal(createCount, 1);
+  assert.equal(adapter.destroyCount, 1);
+  assert.equal(replacement.connectCount, 1);
+  assert.equal(replacement.destroyCount, 0);
+  assert.equal(controller.sockets.get(8901), replacement);
+});
+
+test("marks an Android attempt closed when connect throws synchronously", () => {
+  const adapter = createClientAdapter("Android");
+  net.Socket = class {
+    on() {
+      return this;
+    }
+    connect() {
+      throw new Error("connect failed");
+    }
+    destroy() {}
+  };
+
+  adapter.connect();
+
+  assert.equal(adapter.isAttemptActive(), false);
+  assert.equal(adapter.isClosed(), true);
+});
+
+test("marks an iOS attempt closed when tunnel creation rejects", async () => {
+  const adapter = createClientAdapter("iOS");
+  usbmux.getTunnel = () => Promise.reject(new Error("tunnel failed"));
+
+  adapter.connect();
+  assert.equal(adapter.isAttemptActive(), true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(adapter.isAttemptActive(), false);
+  assert.equal(adapter.isClosed(), true);
+});
+
+test("a late iOS tunnel is destroyed after its controller attempt closes", async () => {
+  const tunnelResult = deferred();
+  const tunnel = {
+    destroyCount: 0,
+    writeCount: 0,
+    destroy() {
+      this.destroyCount++;
+    },
+    write() {
+      this.writeCount++;
+    },
+  };
+  let registered = 0;
+  const adapter = new ClientAdapter(
+    createDriver(),
+    {
+      onConnectionCreated() {
+        registered++;
+        return 7;
+      },
+      onConnectionDeleted() {},
+    },
+    8901,
+    "device",
+    "serial",
+    "iOS",
+    "127.0.0.1",
+  );
+  usbmux.getTunnel = () => tunnelResult.promise;
+
+  adapter.connect();
+  adapter.destroy();
+  tunnelResult.resolve(tunnel);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(tunnel.destroyCount, 1);
+  assert.equal(tunnel.writeCount, 0);
+  assert.equal(registered, 0);
+  assert.equal(adapter.isClosed(), true);
+});
+
+test("Initialize failure closes the attempt instead of leaving it active", () => {
+  for (const socket of [
+    {
+      destroyed: false,
+      writable: false,
+      destroy() {},
+      write() {
+        throw new Error("must not write");
+      },
+    },
+    {
+      destroyed: false,
+      writable: true,
+      destroy() {},
+      write() {
+        throw new Error("write failed");
+      },
+    },
+  ]) {
+    const deleted = [];
+    const adapter = createClientAdapter("Android", deleted);
+    adapter.state = "active";
+    adapter.tcpClient = socket;
+
+    adapter.onConnect();
+
+    assert.equal(adapter.isAttemptActive(), false);
+    assert.equal(adapter.isClosed(), true);
+    assert.deepEqual(deleted, [0]);
+  }
+});
+
+test("close destroys every adapter and unregisters each route exactly once", () => {
+  const driver = createDriver();
+  const controller = new ClientController(driver, createDevice([8901, 8902]));
+  const firstAdapter = createAdapter("active");
+  const secondAdapter = createAdapter("active");
+
+  controller.sockets = new Map([
+    [8901, firstAdapter],
+    [8902, secondAdapter],
+  ]);
+  controller.connections = new Map([[7, {}]]);
+  controller.clientInfos = new Map([[7, 8901]]);
+  controller.ports = new Map([
+    [8901, true],
+    [8902, false],
+  ]);
+
+  controller.close();
+  controller.close();
+  controller.onConnectionDeleted(7);
+
+  assert.deepEqual(driver.unregistered, [7]);
+  assert.equal(firstAdapter.destroyCount, 1);
+  assert.equal(secondAdapter.destroyCount, 1);
+  assert.equal(controller.sockets.size, 0);
+  assert.equal(controller.connections.size, 0);
+  assert.equal(controller.clientInfos.size, 0);
+  assert.equal(controller.ports.size, 0);
+});
+
+test("a late Register cannot publish a route after controller close", () => {
+  const driver = createDriver();
+  const controller = new ClientController(driver, createDevice());
+  let connectionCloseCount = 0;
+  const connection = {
+    close() {
+      connectionCloseCount++;
+    },
+  };
+
+  controller.close();
+  const id = controller.onConnectionCreated(connection, 8901, {});
+
+  assert.equal(id, 0);
+  assert.equal(connectionCloseCount, 1);
+  assert.equal(controller.connections.size, 0);
+  assert.equal(driver.registered.length, 0);
+});
+
+test("Android error then close cannot unregister a replacement route", async () => {
+  class FakeSocket extends require("node:events") {
+    connecting = false;
+    destroyed = false;
+    writable = true;
+    connect() {}
+    destroy() {
+      this.destroyed = true;
+    }
+    end() {}
+    write() {
+      return true;
+    }
+  }
+  net.Socket = FakeSocket;
+  const driver = createDriver();
+  let nextId = 6;
+  driver.createClientId = () => ++nextId;
+  const controller = new ClientController(driver, createDevice());
+  const register = JSON.stringify({
+    data: { info: { App: "app", sdkVersion: "1.0" } },
+    event: "Register",
+  });
+
+  controller.watchClient();
+  const oldAdapter = controller.sockets.get(8901);
+  const oldSocket = oldAdapter.tcpClient;
+  await oldAdapter.handleConnection(register);
+  assert.equal(oldAdapter.id, 7);
+
+  oldSocket.emit("error", new Error("old connection failed"));
+  controller.watchClient();
+  const newAdapter = controller.sockets.get(8901);
+  await newAdapter.handleConnection(register);
+  assert.equal(newAdapter.id, 8);
+
+  oldSocket.emit("close", true);
+
+  assert.deepEqual(driver.unregistered, [7]);
+  assert.equal(controller.connections.has(7), false);
+  assert.equal(controller.connections.has(8), true);
+  assert.equal(controller.sockets.get(8901), newAdapter);
+  controller.close();
+});
+
+test("same ports reuse the controller; changed ports close it before reconnect", () => {
+  process.env.DriverAutoFindClientsEnv = "false";
+  const driver = createDriver();
+  const connectedPorts = [];
+  let oldAdapter;
+  ClientAdapter.prototype.connect = function () {
+    if (this.port === 8902) {
+      assert.equal(oldAdapter.isClosed(), true);
+      assert.deepEqual(driver.unregistered, [7]);
+    }
+    connectedPorts.push(this.port);
+    this.state = "active";
+  };
+  const device = new TestDevice(driver, [8901]);
+
+  device.startWatchClient();
+  const oldController = device.controller;
+  oldAdapter = oldController.sockets.get(8901);
+  device.startWatchClient();
+  assert.equal(device.controller, oldController);
+  oldController.connections.set(7, {});
+  oldController.clientInfos.set(7, 8901);
+  oldController.ports.set(8901, true);
+
+  device.setPorts([8902]);
+  device.startWatchClient();
+
+  assert.notEqual(device.controller, oldController);
+  assert.deepEqual(connectedPorts, [8901, 8902]);
+  assert.equal(oldAdapter.isClosed(), true);
+  assert.deepEqual(driver.unregistered, [7]);
+  assert.equal(oldController.sockets.size, 0);
+  assert.equal(oldController.connections.size, 0);
+  assert.equal(device.controller.matchesPorts([8902]), true);
+  device.disConnect();
+});
+
+test("driver takeover destroys a pending adapter before ownership resumes", () => {
+  process.env.DriverAutoFindClientsEnv = "false";
+  const connectedPorts = [];
+  ClientAdapter.prototype.connect = function () {
+    connectedPorts.push(this.port);
+    this.state = "active";
+  };
+  const device = new TestDevice(createDriver(), [8901]);
+  const connector = {
+    devices: new Map([[device.serial, device]]),
+    getAllAppClients: () => [],
+  };
+
+  device.startWatchClient();
+  const oldController = device.controller;
+  const pendingAdapter = oldController.sockets.get(8901);
+  DebugRouterConnector.prototype.disableAllClients.call(connector);
+
+  assert.equal(pendingAdapter.isClosed(), true);
+  assert.equal(device.controller, undefined);
+
+  device.startWatchClient();
+  assert.notEqual(device.controller, oldController);
+  assert.deepEqual(connectedPorts, [8901, 8901]);
+  assert.equal(device.controller.sockets.size, 1);
+  device.disConnect();
+});
+
+function createAdapter(initialState) {
+  let state = initialState;
+  return {
+    connectCount: 0,
+    destroyCount: 0,
+    connect() {
+      this.connectCount++;
+      state = "active";
+    },
+    destroy() {
+      this.destroyCount++;
+      state = "closed";
+    },
+    isAttemptActive() {
+      return state === "active";
+    },
+    isClosed() {
+      return state === "closed";
+    },
+    setState(nextState) {
+      state = nextState;
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function createDevice(ports = [8901]) {
+  return {
+    getHost: () => "127.0.0.1",
+    info: { os: "Android", serial: "serial", title: "device" },
+    ports,
+  };
+}
+
+function createDriver() {
+  return {
+    createClientId: () => 7,
+    registered: [],
+    regiserUsbClient(client) {
+      this.registered.push(client);
+    },
+    unregistered: [],
+    unregiserUsbClient(id) {
+      this.unregistered.push(id);
+    },
+    usbConnectOpt: { retryTime: 1_000 },
+  };
+}
+
+function createClientAdapter(type, deleted = []) {
+  return new ClientAdapter(
+    createDriver(),
+    {
+      onConnectionCreated: () => 7,
+      onConnectionDeleted(id) {
+        deleted.push(id);
+      },
+    },
+    8901,
+    "device",
+    "serial",
+    type,
+    "127.0.0.1",
+  );
+}
+
+class TestDevice extends BaseDevice {
+  constructor(driver, ports = []) {
+    super(driver, { os: "Android", serial: "serial", title: "device" });
+    this.port = ports;
+  }
+
+  get controller() {
+    return this.clientController;
+  }
+
+  getHost() {
+    return "127.0.0.1";
+  }
+
+  setPorts(ports) {
+    this.port = ports;
+  }
+}


### PR DESCRIPTION
## Summary

- keep one `ClientAdapter` alive while its TCP/USB handshake is still active instead of replacing it every retry tick
- make repeated device watches idempotent for the same forwarded ports, and fully close the old controller before a changed port generation starts
- destroy pending and registered adapters when driver ownership is transferred; a later owner starts with one fresh controller
- close adapters, routes, late tunnels, and terminal connect/Initialize failures exactly once
- add deterministic connector ownership tests to the public CI workflow

## Root cause

`ClientController.watchClient()` treated “not registered yet” as “connection attempt failed”. With the default 3-second watch interval, it destroyed a valid socket that had sent `Initialize` but was still waiting for `Register`, then created another socket. `BaseDevice.startWatchClient()` could also overwrite a controller without closing the sockets it owned.

This was observed in real Android CI without OOM or an app crash: `Initialize(-1)` and `UsbClient::Stop` repeated every ~3 seconds while `Register` never arrived. The same lifecycle affects CLI and connector users, not only tests.

## Semantics

- an active handshake remains owned until its socket reaches a real terminal state
- a closed attempt may be replaced on the next normal watch tick
- changed ADB-forwarded ports close the old generation before the new one connects
- `disableAllClients()` closes pre-Register sockets as well as registered clients, while ordinary `stopWatchClient()` still only stops discovery
- there is no retry, replay, sleep, or timeout change
- a peer that stays connected forever without `Register` remains follow-up protocol work; recovery needs an explicit handshake terminal/generation signal, not timer-based destruction

## Verification

- `npm test` (10/10)
- Prettier check
- workflow YAML parse
- `git diff --check`
