### PR TITLE
[BugFix] Late-bind stable DebugRouter routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           set -e
           pushd debug_router_connector/
           npm install
-          npm run build
+          npm test
           ls -al
           popd
 

--- a/debug_router_connector/package.json
+++ b/debug_router_connector/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node bin/driver.js start",
     "build": "rm -rf dist && bash ./scripts/build.sh",
+    "test": "npm run build && node --test test/*.test.js",
     "types": "rm -rf lib && rm -rf typings && tsc -p tsconfig.prod.json",
     "format": "prettier --write ."
   },

--- a/debug_router_connector/src/connector/DebugRouterConnector.ts
+++ b/debug_router_connector/src/connector/DebugRouterConnector.ts
@@ -781,20 +781,103 @@ export class DebugRouterConnector {
     }
   }
 
-  handleWsMessage(id: number, message: string) {
-    const client = this.usbClients.get(id);
-    if (client) {
-      const data = JSON.parse(message);
-      if (
-        data?.data?.type === "UsbConnect" ||
-        data?.data?.type === "UsbConnectAck"
-      )
+  handleWsMessage(id: number, message: string, originId?: number) {
+    const data = JSON.parse(message);
+    const debugRouterId =
+      typeof data?.debugRouterId === "string" ? data.debugRouterId : undefined;
+    delete data.debugRouterId;
+
+    let client: Client | undefined;
+    if (debugRouterId === undefined) {
+      client = this.usbClients.get(id);
+    } else {
+      const matches = this.getAllAppClients().filter(
+        (candidate) => this.getDebugRouterId(candidate) === debugRouterId,
+      );
+      if (matches.length !== 1) {
+        this.rejectRoute(
+          originId,
+          debugRouterId,
+          id,
+          matches.length === 0 ? "not_found" : "ambiguous",
+        );
         return;
-      if (data?.data?.data?.client_id) {
-        data.data.data.client_id = -1;
       }
-      client.sendMessage(data);
+      client = matches[0];
     }
+
+    if (!client) {
+      return;
+    }
+    if (
+      data?.data?.type === "UsbConnect" ||
+      data?.data?.type === "UsbConnectAck"
+    )
+      return;
+    if (!this.canSendToClient(client)) {
+      if (debugRouterId !== undefined) {
+        this.rejectRoute(originId, debugRouterId, id, "write_failed");
+      }
+      return;
+    }
+    if (data?.data?.data?.client_id) {
+      data.data.data.client_id = this.isUsbClient(client)
+        ? -1
+        : client.clientId();
+    }
+    data.to = client.clientId();
+    try {
+      this.sendToClient(client, data);
+    } catch (error) {
+      if (debugRouterId !== undefined) {
+        this.rejectRoute(originId, debugRouterId, id, "write_failed");
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  private getDebugRouterId(client: Client): unknown {
+    if (this.isUsbClient(client)) {
+      return client.info.query.raw_info?.debugRouterId;
+    }
+    return (client as WebSocketClient).info.raw_info?.debugRouterId;
+  }
+
+  private canSendToClient(client: Client): boolean {
+    return this.isUsbClient(client)
+      ? client.canSendMessage()
+      : (client as WebSocketClient).canSendMessage();
+  }
+
+  private sendToClient(client: Client, data: unknown) {
+    if (this.isUsbClient(client)) {
+      client.sendMessage(data);
+    } else {
+      (client as WebSocketClient).sendMessage(JSON.stringify(data));
+    }
+  }
+
+  private isUsbClient(client: Client): client is UsbClient {
+    return "query" in (client as UsbClient).info;
+  }
+
+  private rejectRoute(
+    originId: number | undefined,
+    debugRouterId: string,
+    target: number,
+    reason: "not_found" | "ambiguous" | "write_failed",
+  ) {
+    if (originId === undefined) {
+      return;
+    }
+    this.wss?.sendMessageToDriver(
+      originId,
+      JSON.stringify({
+        event: "RouteRejected",
+        data: { debugRouterId, target, reason },
+      }),
+    );
   }
 
   handleUsbClienChange() {

--- a/debug_router_connector/src/usb/Client.ts
+++ b/debug_router_connector/src/usb/Client.ts
@@ -103,6 +103,10 @@ export class UsbClient extends Client {
   }
 
   // just send message
+  canSendMessage(): boolean {
+    return this.connection.canSend();
+  }
+
   sendMessage(message: any) {
     this.connection.send(message);
   }

--- a/debug_router_connector/src/usb/Connection.ts
+++ b/debug_router_connector/src/usb/Connection.ts
@@ -19,6 +19,9 @@ export abstract class Connection {
   private readonly events = new EventEmitter();
   protected pendingRequests: Map<string, PendingRequestResolvers> = new Map();
   abstract close(): void;
+  canSend(): boolean {
+    return true;
+  }
   abstract send(data: any): void;
   abstract sendExpectResponse(
     data: RequireMessageType,

--- a/debug_router_connector/src/usb/USBConnection.ts
+++ b/debug_router_connector/src/usb/USBConnection.ts
@@ -43,6 +43,10 @@ export class USBConnection extends Connection {
     this.socket.end();
   }
 
+  canSend(): boolean {
+    return this.socket.writable && !this.socket.destroyed;
+  }
+
   send(data: any): void {
     if (this.socket.writable) {
       if (process.env.PrintAllUSBMessage === "enable") {

--- a/debug_router_connector/src/websocket/WebSocketConnection.ts
+++ b/debug_router_connector/src/websocket/WebSocketConnection.ts
@@ -54,6 +54,10 @@ export class WebSocketClient extends Client {
     this.socket.send(message);
   }
 
+  canSendMessage(): boolean {
+    return this.socket.readyState === WebSocket.OPEN;
+  }
+
   close() {
     this.socket.close();
   }
@@ -174,7 +178,7 @@ export class WebSocketClient extends Client {
       if (id == -1) {
         return;
       }
-      this.server.sendMessageToApp(id, message);
+      this.server.sendMessageToApp(id, message, this.clientId());
     } else {
       // message from app, only send to web
       const id = data.data?.sender ?? -1;

--- a/debug_router_connector/src/websocket/WebSocketServer.ts
+++ b/debug_router_connector/src/websocket/WebSocketServer.ts
@@ -155,14 +155,30 @@ export class WebSocketController {
     });
   }
 
-  sendMessageToApp(id: number, message: string) {
+  sendMessageToDriver(id: number, message: string) {
+    this.webClients.get(id)?.sendMessage(message);
+  }
+
+  sendMessageToApp(id: number, message: string, originId?: number) {
+    try {
+      const data = JSON.parse(message);
+      if (
+        data?.event === "Customized" &&
+        typeof data.debugRouterId === "string"
+      ) {
+        this.driver.handleWsMessage(id, message, originId);
+        return;
+      }
+    } catch {
+      // Preserve legacy handling for malformed messages.
+    }
     const client = this.websocketAppClients.get(id);
     if (client) {
       // send to ws client app
       client.sendMessage(message);
     } else {
       // send to usb client app
-      this.driver.handleWsMessage(id, message);
+      this.driver.handleWsMessage(id, message, originId);
     }
   }
 

--- a/debug_router_connector/test/stable_route.test.js
+++ b/debug_router_connector/test/stable_route.test.js
@@ -1,0 +1,284 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  DebugRouterConnector,
+} = require("../dist/cjs/src/connector/DebugRouterConnector.js");
+const {
+  WebSocketClient,
+} = require("../dist/cjs/src/websocket/WebSocketConnection.js");
+const {
+  WebSocketController,
+} = require("../dist/cjs/src/websocket/WebSocketServer.js");
+
+test("late-binds a stable route once after its numeric target changes", () => {
+  const oldRoute = createUsbClient(2, "stable-app");
+  const currentRoute = createUsbClient(10, "stable-app");
+  const harness = createConnectorHarness([currentRoute]);
+
+  dispatch(harness.connector, 2, "stable-app");
+
+  assert.equal(oldRoute.messages.length, 0);
+  assert.equal(currentRoute.messages.length, 1);
+  assert.equal(currentRoute.messages[0].debugRouterId, undefined);
+  assert.equal(currentRoute.messages[0].data.data.client_id, -1);
+  assert.deepEqual(harness.rejections, []);
+});
+
+test("rejects missing and ambiguous stable routes only to the originating Driver", () => {
+  for (const { clients, reason } of [
+    { clients: [], reason: "not_found" },
+    {
+      clients: [
+        createUsbClient(10, "stable-app"),
+        createUsbClient(11, "stable-app"),
+      ],
+      reason: "ambiguous",
+    },
+  ]) {
+    const harness = createConnectorHarness(clients);
+
+    dispatch(harness.connector, 2, "stable-app", 91);
+
+    assert.equal(clients.flatMap((client) => client.messages).length, 0);
+    assert.deepEqual(harness.rejections, [
+      {
+        id: 91,
+        message: {
+          event: "RouteRejected",
+          data: {
+            debugRouterId: "stable-app",
+            target: 2,
+            reason,
+          },
+        },
+      },
+    ]);
+  }
+});
+
+test("keeps numeric routing for legacy messages without a stable route", () => {
+  const numericRoute = createUsbClient(2, "stable-app");
+  const harness = createConnectorHarness([numericRoute]);
+
+  dispatch(harness.connector, 2);
+
+  assert.equal(numericRoute.messages.length, 1);
+  assert.equal(numericRoute.messages[0].data.data.client_id, -1);
+  assert.deepEqual(harness.rejections, []);
+});
+
+test("rejects an unwritable stable route without sending to the App", () => {
+  const route = createUsbClient(10, "stable-app", false);
+  const harness = createConnectorHarness([route]);
+
+  dispatch(harness.connector, 2, "stable-app", 91);
+
+  assert.equal(route.messages.length, 0);
+  assert.deepEqual(harness.rejections, [
+    {
+      id: 91,
+      message: {
+        event: "RouteRejected",
+        data: {
+          debugRouterId: "stable-app",
+          target: 2,
+          reason: "write_failed",
+        },
+      },
+    },
+  ]);
+});
+
+test("passes the originating Driver id into route dispatch", () => {
+  const calls = [];
+  const client = {
+    clientId: () => 91,
+    server: {
+      sendMessageToApp(...args) {
+        calls.push(args);
+      },
+    },
+    type: () => "Driver",
+  };
+  const message = createMessage("stable-app");
+
+  WebSocketClient.prototype.handleCustomizedMessage.call(
+    client,
+    message,
+    JSON.stringify(message),
+  );
+
+  assert.deepEqual(calls, [[2, JSON.stringify(message), 91]]);
+});
+
+test("a stable route bypasses a reused numeric WebSocket App id", () => {
+  const staleMessages = [];
+  const routeCalls = [];
+  const message = createMessage("stable-app");
+  const controller = {
+    driver: {
+      handleWsMessage(...args) {
+        routeCalls.push(args);
+      },
+    },
+    websocketAppClients: new Map([
+      [
+        2,
+        {
+          sendMessage: (message) => staleMessages.push(message),
+        },
+      ],
+    ]),
+  };
+
+  WebSocketController.prototype.sendMessageToApp.call(
+    controller,
+    2,
+    JSON.stringify(message),
+    91,
+  );
+
+  assert.deepEqual(staleMessages, []);
+  assert.deepEqual(routeCalls, [[2, JSON.stringify(message), 91]]);
+});
+
+test("keeps the legacy numeric shortcut for WebSocket Apps without a stable route", () => {
+  const appMessages = [];
+  const routeCalls = [];
+  const message = createMessage();
+  const controller = {
+    driver: {
+      handleWsMessage(...args) {
+        routeCalls.push(args);
+      },
+    },
+    websocketAppClients: new Map([
+      [
+        2,
+        {
+          sendMessage: (message) => appMessages.push(message),
+        },
+      ],
+    ]),
+  };
+
+  WebSocketController.prototype.sendMessageToApp.call(
+    controller,
+    2,
+    JSON.stringify(message),
+    91,
+  );
+
+  assert.deepEqual(appMessages, [JSON.stringify(message)]);
+  assert.deepEqual(routeCalls, []);
+});
+
+test("late-binds a stable WebSocket App route once after its numeric id changes", () => {
+  const staleRoute = createWebSocketApp(2, "other-app");
+  const currentRoute = createWebSocketApp(10, "stable-app");
+  const harness = createConnectorHarness([], [staleRoute, currentRoute]);
+
+  dispatch(harness.connector, 2, "stable-app");
+
+  assert.equal(staleRoute.messages.length, 0);
+  assert.equal(currentRoute.messages.length, 1);
+  const routed = JSON.parse(currentRoute.messages[0]);
+  assert.equal(routed.debugRouterId, undefined);
+  assert.equal(routed.data.data.client_id, 10);
+  assert.equal(routed.to, 10);
+  assert.deepEqual(harness.rejections, []);
+});
+
+test("sends a route rejection to one Driver instead of broadcasting", () => {
+  const originMessages = [];
+  const otherMessages = [];
+  const controller = {
+    webClients: new Map([
+      [91, { sendMessage: (message) => originMessages.push(message) }],
+      [92, { sendMessage: (message) => otherMessages.push(message) }],
+    ]),
+  };
+
+  WebSocketController.prototype.sendMessageToDriver.call(
+    controller,
+    91,
+    JSON.stringify({ event: "RouteRejected" }),
+  );
+
+  assert.equal(originMessages.length, 1);
+  assert.equal(otherMessages.length, 0);
+});
+
+function createConnectorHarness(clients, webClients = []) {
+  const rejections = [];
+  return {
+    connector: Object.assign(Object.create(DebugRouterConnector.prototype), {
+      enableWebSocket: webClients.length > 0,
+      usbClients: new Map(clients.map((client) => [client.clientId(), client])),
+      wss: {
+        getAllWebsocketAppClients() {
+          return webClients;
+        },
+        sendMessageToDriver(id, rawMessage) {
+          rejections.push({ id, message: JSON.parse(rawMessage) });
+        },
+      },
+    }),
+    rejections,
+  };
+}
+
+function createWebSocketApp(id, debugRouterId, writable = true) {
+  return {
+    info: { raw_info: { debugRouterId } },
+    messages: [],
+    clientId: () => id,
+    canSendMessage: () => writable,
+    sendMessage(message) {
+      this.messages.push(message);
+    },
+  };
+}
+
+function createUsbClient(id, debugRouterId, writable = true) {
+  return {
+    info: { query: { raw_info: { debugRouterId } } },
+    messages: [],
+    clientId: () => id,
+    canSendMessage: () => writable,
+    sendMessage(message) {
+      this.messages.push(message);
+    },
+  };
+}
+
+function dispatch(connector, target, debugRouterId, origin = 91) {
+  DebugRouterConnector.prototype.handleWsMessage.call(
+    connector,
+    target,
+    JSON.stringify(createMessage(debugRouterId)),
+    origin,
+  );
+}
+
+function createMessage(debugRouterId) {
+  return {
+    event: "Customized",
+    ...(debugRouterId === undefined ? {} : { debugRouterId }),
+    data: {
+      type: "CDP",
+      data: {
+        client_id: 2,
+        message: JSON.stringify({ id: 7, method: "DOM.getDocument" }),
+        session_id: 1,
+      },
+      sender: 91,
+    },
+    to: 2,
+  };
+}


### PR DESCRIPTION
## Summary

- carry the stable `debugRouterId` on Driver `Customized` messages
- resolve the current unique USB/WiFi App route at the actual forwarding point
- return an origin-only `RouteRejected` for missing, ambiguous, or unwritable routes
- preserve the legacy numeric routing path when stable metadata is absent

This removes the `ClientList`-to-write TOCTOU without retrying or replaying a request. The stable ID is stripped before forwarding to the App.

## Verification

- `npm test` (9/9, including TypeScript build and declarations)
- Prettier check
- `git diff --check`

`npm run types` is currently unusable on the base branch because the script references a missing `tsconfig.prod.json`; `npm run build` uses the existing `tsconfig.json` and succeeds.

## Scope

This patch handles synchronous route admission and forwarding. Asynchronous socket errors after a successful write still require an operation ID / acknowledgement protocol and are intentionally not retried.
