### PR TITLE
[BugFix][Connector] Preserve USB adapter ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           set -e
           pushd debug_router_connector/
           npm install
-          npm run build
+          npm test
           ls -al
           popd
 

--- a/debug_router_connector/package.json
+++ b/debug_router_connector/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node bin/driver.js start",
     "build": "rm -rf dist && bash ./scripts/build.sh",
+    "test": "npm run build && node --test test/*.test.js",
     "types": "rm -rf lib && rm -rf typings && tsc -p tsconfig.prod.json",
     "format": "prettier --write ."
   },

--- a/debug_router_connector/src/device/BaseDevice.ts
+++ b/debug_router_connector/src/device/BaseDevice.ts
@@ -55,8 +55,7 @@ export abstract class BaseDevice {
       os: this.info.os,
       title: this.info.title,
     });
-    this.clientController?.stopWatchClient();
-    this.clientController = new ClientController(this.driver, this);
+    this.clientController ??= new ClientController(this.driver, this);
     this.clientController.startWatchClient();
   }
 

--- a/debug_router_connector/src/usb/ClientAdapter.ts
+++ b/debug_router_connector/src/usb/ClientAdapter.ts
@@ -41,6 +41,9 @@ export default class ClientAdapter {
   private offset: number = 0;
   private end: number = 0;
   protected tcpClient: net.Socket = new net.Socket();
+  private connectionAttempt = 0;
+  private isDisposed = false;
+  protected isConnecting = false;
   protected isConnected: boolean = false;
   protected connection: Connection | null = null;
   protected from?: number;
@@ -57,6 +60,12 @@ export default class ClientAdapter {
   ) {}
 
   protected handleData(client: net.Socket, data: Buffer) {
+    if (
+      client !== this.tcpClient ||
+      (!this.isConnecting && !this.isConnected)
+    ) {
+      return;
+    }
     try {
       this.handleUnpackMessage(data);
     } catch (error: any) {
@@ -72,6 +81,14 @@ export default class ClientAdapter {
   }
 
   protected handleOff(client: net.Socket) {
+    if (
+      client !== this.tcpClient ||
+      (!this.isConnecting && !this.isConnected)
+    ) {
+      return;
+    }
+    const id = this.id;
+    this.isConnecting = false;
     this.isConnected = false;
     client.destroy();
     this.driver.traceRecorder?.recordSocketDisconnected(
@@ -84,11 +101,17 @@ export default class ClientAdapter {
       this.connectionAttemptId,
     );
     this.connectionAttemptId = undefined;
+    this.bufferCapacity = this.initialBufferCapacity;
+    this.buffer = null;
+    this.offset = 0;
+    this.end = 0;
+    this.connection = null;
+    this.id = 0;
     if (this.listener === null) {
       defaultLogger.debug("handleOff: this.listener == null");
       return;
     }
-    this.listener.onConnectionDeleted(this.id);
+    this.listener.onConnectionDeleted(id);
   }
 
   protected handleUnpackMessage(data: any) {
@@ -150,7 +173,10 @@ export default class ClientAdapter {
     }
   }
 
-  onConnect(): void {
+  onConnect(client: net.Socket = this.tcpClient): void {
+    if (client !== this.tcpClient || !this.isConnecting) {
+      return;
+    }
     const initialize: InitializeMessageType = {
       event: "Initialize",
       data: -1,
@@ -164,9 +190,9 @@ export default class ClientAdapter {
       },
     );
     try {
-      if (this.tcpClient.writable && !this.tcpClient.destroyed) {
+      if (client.writable && !client.destroyed) {
         defaultLogger.debug("send Initialize:" + this.port);
-        this.tcpClient.write(packMessage(initialize));
+        client.write(packMessage(initialize));
       }
     } catch (err) {
       defaultLogger.debug("send Initialize error:" + JSON.stringify(err));
@@ -271,6 +297,7 @@ export default class ClientAdapter {
         this.port,
         ClientQuery,
       );
+      this.isConnecting = false;
       this.isConnected = true;
     }
   }
@@ -294,18 +321,24 @@ export default class ClientAdapter {
   }
 
   connect(): void {
-    if (this.isConnected || this.tcpClient.connecting) return;
+    if (this.isDisposed || this.isConnected || this.isConnecting) return;
+    this.isConnecting = true;
+    const attempt = ++this.connectionAttempt;
     const platform = this.type;
     if (platform === "iOS") {
       getTunnel(this.port, { udid: this.device_id })
         .then((tunnel: net.Socket) => {
+          if (attempt !== this.connectionAttempt || !this.isConnecting) {
+            tunnel.destroy();
+            return;
+          }
           this.tcpClient = tunnel;
           this.tcpClient.on("data", (data: Buffer) => {
-            this.handleData(this.tcpClient, data);
+            this.handleData(tunnel, data);
           });
           this.tcpClient.on("close", () => {
             defaultLogger.debug("ios device close:" + this.port);
-            this.handleOff(this.tcpClient);
+            this.handleOff(tunnel);
           });
 
           this.tcpClient.on("usbmux_error", (err: Error) => {
@@ -315,11 +348,15 @@ export default class ClientAdapter {
               msg: msg,
               stage: "client",
             });
-            this.handleOff(this.tcpClient);
+            this.handleOff(tunnel);
           });
-          this.onConnect();
+          this.onConnect(tunnel);
         })
         .catch((err: Error) => {
+          if (attempt !== this.connectionAttempt) {
+            return;
+          }
+          this.isConnecting = false;
           const msg =
             "ios connect error:" + this.port + " error:" + err?.message;
           defaultLogger.debug(msg);
@@ -330,11 +367,12 @@ export default class ClientAdapter {
         });
     } else {
       try {
-        this.tcpClient = new net.Socket();
-        this.tcpClient.on("data", (data: Buffer) => {
-          this.handleData(this.tcpClient, data);
+        const tcpClient = new net.Socket();
+        this.tcpClient = tcpClient;
+        tcpClient.on("data", (data: Buffer) => {
+          this.handleData(tcpClient, data);
         });
-        this.tcpClient.on("error", (err: Error) => {
+        tcpClient.on("error", (err: Error) => {
           const msg =
             platform + " device error:" + err?.message + " " + this.port;
           defaultLogger.debug(msg);
@@ -343,22 +381,23 @@ export default class ClientAdapter {
             msg: msg,
             stage: "client",
           });
-          this.handleOff(this.tcpClient);
+          this.handleOff(tcpClient);
         });
 
-        this.tcpClient.on("close", (hadError: boolean) => {
+        tcpClient.on("close", (hadError: boolean) => {
           defaultLogger.debug(
             platform + " device close:" + this.port + " hadError:" + hadError,
           );
-          this.handleOff(this.tcpClient);
+          this.handleOff(tcpClient);
         });
-        this.tcpClient.on("connect", () => {
+        tcpClient.on("connect", () => {
           defaultLogger.debug(platform + " device onConnect:" + this.port);
-          this.onConnect();
+          this.onConnect(tcpClient);
         });
         const host = this.device_host;
-        this.tcpClient.connect({ host: host, port: this.port });
+        tcpClient.connect({ host: host, port: this.port });
       } catch (err: any) {
+        this.isConnecting = false;
         const msg =
           platform + " connect error:" + this.port + " error:" + err?.message;
         defaultLogger.debug(msg);
@@ -374,6 +413,10 @@ export default class ClientAdapter {
   public destroy() {
     defaultLogger.debug("ClientAdapter destroy");
     this.listener = null;
+    this.connectionAttempt += 1;
+    this.isDisposed = true;
+    this.isConnecting = false;
+    this.isConnected = false;
     this.tcpClient.destroy();
     this.buffer = null;
     this.connection = null;

--- a/debug_router_connector/src/usb/ClientController.ts
+++ b/debug_router_connector/src/usb/ClientController.ts
@@ -98,34 +98,16 @@ export class ClientController implements ClientEventsListener {
     this.driver.unregiserUsbClient(id);
   }
 
-  private createAdapter(
-    connectAdapter: ClientAdapter | undefined,
-    port: number,
-  ): ClientAdapter {
-    return new ClientAdapter(
-      this.driver,
-      this,
-      port,
-      this.device.info.title,
-      this.device.info.serial,
-      this.device.info.os,
-      this.device.getHost(),
-    );
-  }
-
   private watchClient() {
     for (const port of this.ports.keys()) {
       if (!this.ports.get(port)) {
         const connectAdapter = this.sockets.get(port);
-        const newAdapter = this.createAdapter(connectAdapter, port);
-        connectAdapter?.destroy();
-        if (newAdapter === null) {
-          defaultLogger.debug("newAdapter === null:" + port);
-          return;
+        if (!connectAdapter) {
+          defaultLogger.debug("connectAdapter === undefined:" + port);
+          continue;
         }
-        this.sockets.set(port, newAdapter);
         defaultLogger.debug("watchClient:connect:" + port);
-        newAdapter.connect();
+        connectAdapter.connect();
       }
     }
   }
@@ -136,6 +118,7 @@ export class ClientController implements ClientEventsListener {
       defaultLogger.warn("AutoFinding new client is closed for debug");
       return;
     }
+    if (this.timer) return;
     this.timer = setInterval(() => {
       this.watchClient();
     }, this.driver.usbConnectOpt.retryTime);
@@ -144,6 +127,7 @@ export class ClientController implements ClientEventsListener {
   stopWatchClient(): void {
     if (this.timer) {
       clearInterval(this.timer);
+      this.timer = undefined;
     }
   }
 
@@ -157,5 +141,7 @@ export class ClientController implements ClientEventsListener {
   close() {
     this.stopWatchClient();
     this.closeAllConnection();
+    this.sockets.forEach((adapter) => adapter.destroy());
+    this.sockets.clear();
   }
 }

--- a/debug_router_connector/test/ClientController.test.js
+++ b/debug_router_connector/test/ClientController.test.js
@@ -1,0 +1,132 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const test = require("node:test");
+const rewire = require("rewire");
+const { packMessage } = require("../dist/cjs/src/usb/utils.js");
+const {
+  WebSocketClient,
+} = require("../dist/cjs/src/websocket/WebSocketConnection.js");
+const stableId = "stable-debug-router-id";
+const register = packMessage({
+  event: "Register",
+  data: { info: { debugRouterId: stableId } },
+});
+class FakeSocket extends EventEmitter {
+  constructor(all) {
+    super();
+    this.destroyed = false;
+    all.push(this);
+  }
+  connect() {}
+  connected() {
+    this.writable = true;
+    this.emit("connect");
+  }
+  destroy() {
+    this.destroyed = true;
+  }
+  write() {}
+}
+test("keeps one device-port owner through Register and restores ClientList", (t) => {
+  const sockets = [];
+  const controllerModule = rewire("../dist/cjs/src/usb/ClientController.js");
+  controllerModule.__set__("ClientAdapter_1", {
+    default: adapterClass(sockets),
+  });
+  const deviceModule = rewire("../dist/cjs/src/device/BaseDevice.js");
+  deviceModule.__set__("ClientController_1", {
+    ClientController: controllerModule.ClientController,
+  });
+  const clients = new Map();
+  let deleted = 0;
+  let id = 0;
+  const driver = {
+    createClientId: () => ++id,
+    regiserUsbClient: (client) => clients.set(client.clientId(), client),
+    usbConnectOpt: { retryTime: 60_000 },
+    unregiserUsbClient(clientId) {
+      if (clients.delete(clientId)) deleted += 1;
+    },
+  };
+  class Device extends deviceModule.BaseDevice {
+    getHost() {
+      return "";
+    }
+  }
+  const device = new Device(driver, {
+    os: "Android",
+    serial: "device",
+    title: "Android",
+  });
+  device.port = [8901];
+  t.after(() => device.disConnect());
+  device.startWatchClient();
+  const controller = device.clientController;
+  const first = sockets.at(-1);
+  first.connected();
+  device.startWatchClient();
+  assert.equal(sockets.at(-1), first);
+  first.emit("data", register);
+  first.emit("error", new Error("closed"));
+  first.emit("close", true);
+  first.emit("data", register);
+  assert.equal(clients.size, 0);
+  assert.equal(deleted, 1);
+  device.startWatchClient();
+  const second = sockets.at(-1);
+  second.connected();
+  device.startWatchClient();
+  assert.equal(sockets.at(-1), second);
+  first.emit("data", register);
+  first.emit("close", true);
+  assert.equal(deleted, 1);
+  assert.equal(second.destroyed, false);
+  second.emit("data", register);
+  const sent = [];
+  WebSocketClient.prototype.handleListClients.call({
+    clientId: () => 999,
+    info: { id: 999, type: "Driver" },
+    server: {
+      getAllUsbClients: () => [...clients.values()],
+      getAllWebsocketAppClients: () => [],
+    },
+    socket: { send: (message) => sent.push(message) },
+  });
+  const listed = JSON.parse(sent[0]).data;
+  assert.equal(listed[0].info.debugRouterId, stableId);
+  device.disConnect();
+  assert.equal(second.destroyed, true);
+  assert.equal(controller.sockets.size, 0);
+});
+test("rejects stale socket events and a late iOS tunnel", async () => {
+  const sockets = [];
+  let resolveTunnel;
+  const tunnelPromise = new Promise((resolve) => (resolveTunnel = resolve));
+  const Adapter = adapterClass(sockets, () => tunnelPromise);
+  const listener = {
+    onConnectionCreated: assert.fail,
+    onConnectionDeleted() {},
+  };
+  const adapter = new Adapter({}, listener, 8901, "iOS", "device", "iOS", "");
+  adapter.connect();
+  adapter.destroy();
+  const tunnel = new FakeSocket(sockets);
+  resolveTunnel(tunnel);
+  await tunnelPromise;
+  assert.equal(tunnel.destroyed, true);
+  assert.equal(tunnel.listenerCount("data"), 0);
+});
+function adapterClass(sockets, getTunnel) {
+  const module = rewire("../dist/cjs/src/usb/ClientAdapter.js");
+  class Socket extends FakeSocket {
+    constructor() {
+      super(sockets);
+    }
+  }
+  module.__set__("net", { Socket });
+  if (getTunnel) module.__set__("usbmux_1", { getTunnel });
+  return module.default;
+}


### PR DESCRIPTION
## Summary

- keep one ClientAdapter owner for each device port instead of replacing it on every discovery tick
- keep the connecting state through Register, reject stale socket callbacks, and clean up terminal generations exactly once
- reuse the device controller across repeated discovery calls and destroy late iOS tunnels after shutdown
- run the new deterministic regression tests in the connector GitHub CI job

## Why

ClientController marked a port connected only after Register. Between TCP connect and Register, the next discovery tick saw the port as disconnected, destroyed the in-flight adapter, and created another socket. Repeated connectUsbClients calls also replaced the whole controller without closing the previous socket owner. This made a registered stable debugRouterId disappear from ClientList even while the device remained healthy.

This change preserves one owner across the complete TCP-to-Register handshake. It does not change the retry interval, replay requests, or add timeouts.

## Verification

- npm test (2/2)
- npm run build
- npx prettier --check .
- mutation checks confirm the tests fail when either repeated device start replaces the controller or a terminal socket accepts a late Register

This fixes the pre-Register ownership gap. Post-Register route rejection and request correlation remain separate protocol work.
