### PR TITLE
[BugFix] Reject unavailable Lynx DevTool routes

### DIFF
--- a/debug_router_connector/src/connector/DebugRouterConnector.ts
+++ b/debug_router_connector/src/connector/DebugRouterConnector.ts
@@ -781,7 +781,11 @@ export class DebugRouterConnector {
     }
   }
 
-  handleWsMessage(id: number, message: string) {
+  handleWsMessage(id: number, message: string): void {
+    this.tryHandleWsMessage(id, message);
+  }
+
+  tryHandleWsMessage(id: number, message: string): boolean {
     const client = this.usbClients.get(id);
     if (client) {
       const data = JSON.parse(message);
@@ -789,12 +793,13 @@ export class DebugRouterConnector {
         data?.data?.type === "UsbConnect" ||
         data?.data?.type === "UsbConnectAck"
       )
-        return;
+        return true;
       if (data?.data?.data?.client_id) {
         data.data.data.client_id = -1;
       }
-      client.sendMessage(data);
+      return client.trySendMessage(data);
     }
+    return false;
   }
 
   handleUsbClienChange() {

--- a/debug_router_connector/src/usb/Client.ts
+++ b/debug_router_connector/src/usb/Client.ts
@@ -107,6 +107,10 @@ export class UsbClient extends Client {
     this.connection.send(message);
   }
 
+  trySendMessage(message: any): boolean {
+    return this.connection.trySend(message);
+  }
+
   // send ClientMessageHandler message and wait result
   sendClientMessage(method: string, params: Object = {}): Promise<string> {
     return this.sendCustomizedMessage(method, params, -1, "App");

--- a/debug_router_connector/src/usb/Connection.ts
+++ b/debug_router_connector/src/usb/Connection.ts
@@ -20,6 +20,14 @@ export abstract class Connection {
   protected pendingRequests: Map<string, PendingRequestResolvers> = new Map();
   abstract close(): void;
   abstract send(data: any): void;
+  trySend(data: any): boolean {
+    try {
+      this.send(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   abstract sendExpectResponse(
     data: RequireMessageType,
   ): Promise<ResponseMessageType>;

--- a/debug_router_connector/src/usb/USBConnection.ts
+++ b/debug_router_connector/src/usb/USBConnection.ts
@@ -51,6 +51,18 @@ export class USBConnection extends Connection {
       this.socket.write(packMessage(data));
     }
   }
+
+  trySend(data: any): boolean {
+    if (!this.socket.writable) {
+      return false;
+    }
+    try {
+      this.send(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   sendExpectResponse(
     require: RequireMessageType,
   ): Promise<ResponseMessageType> {

--- a/debug_router_connector/src/websocket/WebSocketConnection.ts
+++ b/debug_router_connector/src/websocket/WebSocketConnection.ts
@@ -174,7 +174,12 @@ export class WebSocketClient extends Client {
       if (id == -1) {
         return;
       }
-      this.server.sendMessageToApp(id, message);
+      if (!this.server.trySendMessageToApp(id, message)) {
+        defaultLogger.warn(
+          `RouteRejected: client ${String(id).slice(0, 64)} is unavailable`,
+        );
+        this.socket.close(1011, "RouteRejected");
+      }
     } else {
       // message from app, only send to web
       const id = data.data?.sender ?? -1;

--- a/debug_router_connector/src/websocket/WebSocketServer.ts
+++ b/debug_router_connector/src/websocket/WebSocketServer.ts
@@ -155,15 +155,19 @@ export class WebSocketController {
     });
   }
 
-  sendMessageToApp(id: number, message: string) {
+  sendMessageToApp(id: number, message: string): void {
+    this.trySendMessageToApp(id, message);
+  }
+
+  trySendMessageToApp(id: number, message: string): boolean {
     const client = this.websocketAppClients.get(id);
     if (client) {
       // send to ws client app
       client.sendMessage(message);
-    } else {
-      // send to usb client app
-      this.driver.handleWsMessage(id, message);
+      return true;
     }
+    // send to usb client app
+    return this.driver.tryHandleWsMessage(id, message);
   }
 
   sendClientList() {

--- a/test/e2e_test/connector_test/debug_router_connector_auto_test.js
+++ b/test/e2e_test/connector_test/debug_router_connector_auto_test.js
@@ -4,10 +4,15 @@ const fs = require("fs");
 const net = require("net");
 const os = require("os");
 const path = require("path");
+const { WebSocket } = require("ws");
 
 const {
   DebugRouterConnector,
+  UsbClient,
 } = require("@lynx-js/debug-router-connector");
+const {
+  USBConnection,
+} = require("@lynx-js/debug-router-connector/dist/cjs/src/usb/USBConnection");
 
 const DEFAULT_ANDROID_ACTIVITY =
   "com.lynx.debugrouter.testapp/com.lynx.debugrouter.testapp.MainActivity";
@@ -353,9 +358,212 @@ async function runEmptyDiscoveryCheck() {
     const devices = await driver.connectDevices(100);
     assert.deepStrictEqual(devices, []);
 
-    const clients = await driver.connectUsbClients("missing-device", 100, false);
+    const clients = await driver.connectUsbClients(
+      "missing-device",
+      100,
+      false,
+    );
     assert.deepStrictEqual(clients, []);
     assert.deepStrictEqual(driver.getConnectionTrace(), []);
+  } finally {
+    await driver.close();
+  }
+}
+
+async function connectWebDriver(port) {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/mdevices/page/android`);
+  const initialize = await withTimeout(
+    new Promise((resolve, reject) => {
+      socket.on("message", (data) => {
+        const message = JSON.parse(data.toString());
+        if (message.event === "Initialize") {
+          resolve(message);
+        }
+      });
+      socket.once("error", reject);
+    }),
+    1000,
+    "Lynx DevTool driver initialization",
+  );
+  const roomJoined = withTimeout(
+    new Promise((resolve, reject) => {
+      socket.on("message", (data) => {
+        const message = JSON.parse(data.toString());
+        if (message.event === "RoomJoined") {
+          resolve();
+        }
+      });
+      socket.once("error", reject);
+    }),
+    1000,
+    "Lynx DevTool driver registration",
+  );
+  socket.send(
+    JSON.stringify({
+      event: "Register",
+      data: { id: initialize.data, type: "Driver" },
+    }),
+  );
+  await roomJoined;
+  return socket;
+}
+
+async function expectRouteRejected(socket, target) {
+  const closed = withTimeout(
+    new Promise((resolve) => {
+      socket.once("close", (code, reason) => {
+        resolve({ code, reason: reason.toString() });
+      });
+    }),
+    1000,
+    `route ${target} rejection`,
+  );
+  socket.send(
+    JSON.stringify({
+      event: "Customized",
+      data: {
+        type: "App",
+        data: { client_id: target, message: { method: "App.Test" } },
+      },
+    }),
+  );
+  assert.deepStrictEqual(await closed, {
+    code: 1011,
+    reason: "RouteRejected",
+  });
+}
+
+async function runRouteRejectionCheck() {
+  logStep(
+    "checking unavailable Lynx DevTool routes fail the originating driver",
+  );
+  const driver = new DebugRouterConnector({
+    manualConnect: true,
+    enableWebSocket: true,
+    enableAndroid: false,
+    enableIOS: false,
+    enableHarmony: false,
+    enableDesktop: false,
+    enableNetworkDevice: false,
+  });
+
+  try {
+    await driver.startWSServer();
+    const observerSocket = await connectWebDriver(driver.wssPort);
+    await expectRouteRejected(await connectWebDriver(driver.wssPort), 404);
+    await expectRouteRejected(
+      await connectWebDriver(driver.wssPort),
+      "无效路由".repeat(100),
+    );
+
+    const unwritableClientId = 405;
+    const socket = await connectWebDriver(driver.wssPort);
+    driver.usbClients.set(
+      unwritableClientId,
+      new UsbClient(
+        { id: unwritableClientId, query: {} },
+        new USBConnection({ writable: false }),
+      ),
+    );
+    await expectRouteRejected(socket, unwritableClientId);
+    driver.usbClients.delete(unwritableClientId);
+
+    const writeFailureClientId = 407;
+    const writeFailureSocket = await connectWebDriver(driver.wssPort);
+    const writeFailureConnection = new USBConnection({
+      writable: true,
+      write() {
+        throw new Error("socket write failed");
+      },
+    });
+    assert.throws(
+      () =>
+        writeFailureConnection.send({
+          event: "Customized",
+          data: { type: "App", data: { message: {} } },
+        }),
+      /socket write failed/,
+    );
+    driver.usbClients.set(
+      writeFailureClientId,
+      new UsbClient(
+        { id: writeFailureClientId, query: {} },
+        writeFailureConnection,
+      ),
+    );
+    await expectRouteRejected(writeFailureSocket, writeFailureClientId);
+    driver.usbClients.delete(writeFailureClientId);
+
+    const backpressuredClientId = 408;
+    let backpressuredWrites = 0;
+    const backpressuredSocket = await connectWebDriver(driver.wssPort);
+    driver.usbClients.set(
+      backpressuredClientId,
+      new UsbClient(
+        { id: backpressuredClientId, query: {} },
+        new USBConnection({
+          writable: true,
+          write() {
+            backpressuredWrites += 1;
+            return false;
+          },
+        }),
+      ),
+    );
+    backpressuredSocket.send(
+      JSON.stringify({
+        event: "Customized",
+        data: {
+          type: "App",
+          data: {
+            client_id: backpressuredClientId,
+            message: { method: "App.Test" },
+          },
+        },
+      }),
+    );
+    await waitFor(
+      () => backpressuredWrites === 1,
+      1000,
+      "backpressured Lynx DevTool route forwarding",
+    );
+    assert.strictEqual(backpressuredSocket.readyState, WebSocket.OPEN);
+    backpressuredSocket.close();
+    driver.usbClients.delete(backpressuredClientId);
+
+    const writableClientId = 406;
+    const receivedMessages = [];
+    const writableSocket = await connectWebDriver(driver.wssPort);
+    driver.usbClients.set(writableClientId, {
+      clientId: () => writableClientId,
+      close() {},
+      trySendMessage(message) {
+        receivedMessages.push(message);
+        return true;
+      },
+    });
+    writableSocket.send(
+      JSON.stringify({
+        event: "Customized",
+        data: {
+          type: "App",
+          data: {
+            client_id: writableClientId,
+            message: { method: "App.Test" },
+          },
+        },
+      }),
+    );
+    await waitFor(
+      () => receivedMessages.length === 1,
+      1000,
+      "writable Lynx DevTool route forwarding",
+    );
+    assert.strictEqual(writableSocket.readyState, WebSocket.OPEN);
+    writableSocket.close();
+    driver.usbClients.delete(writableClientId);
+    assert.strictEqual(observerSocket.readyState, WebSocket.OPEN);
+    observerSocket.close();
   } finally {
     await driver.close();
   }
@@ -596,7 +804,9 @@ async function runRealDeviceScenario(args) {
     );
 
     logStep(
-      `connected ${device.serial} (${device.info.os}) client=${client.clientId()} app=${client.info.query.app}`,
+      `connected ${device.serial} (${
+        device.info.os
+      }) client=${client.clientId()} app=${client.info.query.app}`,
     );
   } finally {
     await driver?.close();
@@ -608,6 +818,7 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.mode === "no-device") {
     await runEmptyDiscoveryCheck();
+    await runRouteRejectionCheck();
     await runFakeNetworkCheck();
   } else {
     await runRealDeviceScenario(args);


### PR DESCRIPTION
## Summary

- add a backward-compatible forwarding admission path while preserving the existing public `void` APIs
- close only the originating Lynx DevTool Driver with WebSocket `1011 / RouteRejected` when its device route is missing or unwritable
- preserve normal socket backpressure and leave observers and unrelated routes connected
- do not retry or replay rejected messages

## Test plan

- `npm run build` in `debug_router_connector`
- `npm run test:without-device` in `test/e2e_test/connector_test`

Closes #171