### PR TITLE
[Optimize][DevTool] Keep routine protocol payloads at verbose level

### DIFF
--- a/debug_router/native/core/session_filter_util.cc
+++ b/debug_router/native/core/session_filter_util.cc
@@ -66,11 +66,11 @@ bool ShouldDropIncomingBySessionFilter(const std::string &message,
   }
 
   if (!transport_name.empty()) {
-    LOGV(std::string(transport_name) +
+    LOGI(std::string(transport_name) +
          " drop incoming message for inactive session_id: " +
          std::to_string(session_id));
   } else {
-    LOGV("Drop incoming message for inactive session_id: " +
+    LOGI("Drop incoming message for inactive session_id: " +
          std::to_string(session_id));
   }
   return true;

--- a/debug_router/native/log/logging.cc
+++ b/debug_router/native/log/logging.cc
@@ -35,7 +35,7 @@ const char *log_severity_name(int severity) {
 // the log level to output
 bool hasSetDelegate = false;
 
-int g_min_log_level = DEBUGROUTER_LOG_LEVEL_VERBOSE;
+int g_min_log_level = DEBUGROUTER_LOG_LEVEL_INFO;
 
 LoggingDestination g_logging_destination = LOG_DEFAULT;
 

--- a/debug_router/native/net/websocket_task.cc
+++ b/debug_router/native/net/websocket_task.cc
@@ -129,7 +129,7 @@ void WebSocketTask::SendInternal(const std::string &data) {
   } else if (data.find("Lynx.screenshotCapture") != std::string::npos) {
     LOGI("WebSocketTask: [TX]: Lynx.screenshotCapture Sent.");
   } else {
-    LOGI("WebSocketTask: [TX]: " << buf);
+    LOGV("WebSocketTask: [TX]: " << buf);
   }
   if (base::SendNoSigPipe(socket_guard_->Get(), prefix, prefix_len) == -1) {
     LOGE("send prefix_len error.");
@@ -161,7 +161,7 @@ void WebSocketTask::StartInternal() {
 
   std::string msg;
   while (do_read(msg)) {
-    LOGI("[RX]:" << msg);
+    LOGV("[RX]:" << msg);
     if (core::internal::ShouldDropIncomingBySessionFilter(msg, "WebSocket")) {
       continue;
     }

--- a/debug_router/native/processor/processor.cc
+++ b/debug_router/native/processor/processor.cc
@@ -223,7 +223,7 @@ void Processor::HandleAppAction(
   if (message_handler_) {
     result = message_handler_->HandleAppAction(app_message_data->method_,
                                                app_message_data->params_);
-    LOGI("MessageHandler: sync result:" << result);
+    LOGV("MessageHandler: sync result:" << result);
   }
   const std::string method =
       (app_message_data ? app_message_data->method_ : "");

--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -342,7 +342,7 @@ void UsbClient::ReadMessage() {
 
     std::string payload_str(payload.get(), payload_size_int);
 
-    LOGI("[RX]:" << payload_str);
+    LOGV("[RX]:" << payload_str);
     if (core::internal::ShouldDropIncomingBySessionFilter(payload_str, "USB")) {
       continue;
     }
@@ -434,14 +434,13 @@ void UsbClient::WriteMessage() {
       } else if (message.find("Lynx.screenshotCapture") != std::string::npos) {
         LOGI("UsbClient: [TX]: Lynx.screenshotCapture Sent.");
       } else {
-        LOGI("UsbClient: [TX]:");
-        LOGI(message);
+        LOGV("UsbClient: [TX]: " << message);
       }
       std::string result_message;
       WrapHeader(message, result_message);
       if (base::SendNoSigPipe(socket_guard_.Get(), result_message.c_str(),
                               result_message.size()) == -1) {
-        LOGE("send error: " << GetErrorMessage() << " message:" << message);
+        LOGE("send error: " << GetErrorMessage());
         BeginTransportShutdown();
         NotifyErrorOnce(GetErrorMessage(),
                         "UsbClient::WriteMessage send data failed.");
@@ -517,7 +516,7 @@ void UsbClient::SendInternal(const std::string &message) {
   if (stopping_.load(std::memory_order_relaxed) ||
       connect_status_.load(std::memory_order_relaxed) !=
           USBConnectStatus::CONNECTED) {
-    LOGI("current usb client is not connected:" << message);
+    LOGI("current usb client is not connected.");
     return;
   }
   std::string non_const_message = message;

--- a/debug_router/native/test/BUILD.gn
+++ b/debug_router/native/test/BUILD.gn
@@ -74,6 +74,7 @@ unit_test("example_unittest") {
     "count_down_latch_unittest.cc",
     "debug_router_core_concurrency_unittest.cc",
     "example_source_unittest.cc",
+    "logging_unittest.cc",
     "session_filter_util_unittest.cc",
     "socket_server_posix_unittest.cc",
     "socket_server_smoke_unittest.cc",

--- a/debug_router/native/test/logging_unittest.cc
+++ b/debug_router/native/test/logging_unittest.cc
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "debug_router/native/log/logging.h"
+
+#include "gtest/gtest.h"
+
+namespace debugrouter {
+namespace logging {
+namespace {
+
+TEST(LoggingTestSuite, DefaultInfoSkipsVerbosePayloadExpression) {
+  const int previous_level = GetMinLogLevel();
+  EXPECT_EQ(previous_level, LOG_INFO);
+  int payload_expression_evaluations = 0;
+
+  SetMinLogLevel(LOG_INFO);
+  LOGV("protocol-payload-log-probe" << ++payload_expression_evaluations);
+  EXPECT_EQ(payload_expression_evaluations, 0);
+
+  SetMinLogLevel(LOG_VERBOSE);
+  LOGV("protocol-payload-log-probe" << ++payload_expression_evaluations);
+  EXPECT_EQ(payload_expression_evaluations, 1);
+
+  SetMinLogLevel(previous_level);
+}
+
+}  // namespace
+}  // namespace logging
+}  // namespace debugrouter


### PR DESCRIPTION
## Summary

- use INFO as the native fallback log level
- keep complete routine USB/WebSocket payloads and synchronous response bodies at native VERBOSE
- keep compact lifecycle, send-failure, and inactive-session diagnostics visible at INFO or above
- verify that verbose payload expressions are not evaluated at the default INFO level

## Why

Inbound protocol logging currently happens before dispatch, and Android logging can synchronously allocate a managed string through JNI. Under memory pressure, that allocation can block the transport thread and amplify payload retention and log volume.

This patch removes that avoidable work from the default transport path. It does not change routing, protocol messages, retries, or deadlines, and it does not claim to prevent arbitrary app-wide GC or OOM stalls.

Android callers can still explicitly select VERBOSE when complete payload logs are required.

## Test plan

- built the native example_unittest target
- native unit tests: 44/44
- focused logging and session-filter tests: 7/7
- JNI_OnLoad harness: all 8 scenarios
- clang-format dry run
- git diff --check

Closes #174