### PR TITLE
[BugFix] Make socket listener shutdown deterministic

### DIFF
--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -9,6 +9,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <memory>
+
 #include "debug_router/native/core/util.h"
 #include "debug_router/native/log/logging.h"
 #include "debug_router/native/socket/usb_client.h"
@@ -20,13 +22,12 @@ SocketServerPosix::SocketServerPosix(
     const std::shared_ptr<SocketServerConnectionListener> &listener)
     : SocketServer(listener) {}
 
-SocketServerPosix::~SocketServerPosix() { Close(); }
+SocketServerPosix::~SocketServerPosix() { StopServer(); }
 
 int32_t SocketServerPosix::InitSocket() {
   LOGI("SocketServerPosix::InitSocket");
 
   const SocketType socket_fd = socket(AF_INET, SOCK_STREAM, 0);
-  socket_fd_.store(socket_fd, std::memory_order_release);
   if (socket_fd == kInvalidSocket) {
     LOGE("create socket error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "create socket error");
@@ -35,7 +36,7 @@ int32_t SocketServerPosix::InitSocket() {
 
   int on = 1;
   if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
-    Close();
+    CloseSocket(socket_fd);
     LOGE("setsockopt error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "setsockopt error");
     return kInvalidPort;
@@ -60,7 +61,7 @@ int32_t SocketServerPosix::InitSocket() {
            (GetErrorMessage() == EADDRINUSE));
 
   if (!flag) {
-    Close();
+    CloseSocket(socket_fd);
     LOGE("bind address error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "bind address error");
     return kInvalidPort;
@@ -69,9 +70,13 @@ int32_t SocketServerPosix::InitSocket() {
   LOGI("bind port:" << port);
 
   if (listen(socket_fd, kConnectionQueueMaxLength) != 0) {
-    Close();
+    CloseSocket(socket_fd);
     LOGE("listen error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "listen error");
+    return kInvalidPort;
+  }
+  if (!TryPublishSocket(socket_fd)) {
+    CloseSocket(socket_fd);
     return kInvalidPort;
   }
   return port;
@@ -94,28 +99,30 @@ void SocketServerPosix::Start() {
   SocketType accept_socket_fd =
       accept(socket_fd, (struct sockaddr *)(&addr), &addrLen);
   if (accept_socket_fd == kInvalidSocket) {
+    const int error = GetErrorMessage();
     Close();
-    LOGE("accept socket error:" << GetErrorMessage());
-    NotifyInit(GetErrorMessage(), "accept socket error");
+    LOGE("accept socket error:" << error);
+    NotifyInit(error, "accept socket error");
     return;
   }
   LOGI("accept usbclient socket:" << accept_socket_fd);
   std::shared_ptr<UsbClient> old_temp_client;
   LOGI("create a new usb client.");
   auto new_temp_client = std::make_shared<UsbClient>(accept_socket_fd);
-  {
-    std::lock_guard<std::mutex> lock(client_lock_);
-    old_temp_client = temp_usb_client_;
-    temp_usb_client_ = new_temp_client;
+  if (!TryInstallPendingClient(new_temp_client, &old_temp_client)) {
+    return;
   }
   if (old_temp_client) {
     LOGI("close last connector, destroy temp_usb_client_.");
     ScheduleClientStop(old_temp_client);
   }
   std::shared_ptr<ClientListener> listener =
-      std::make_shared<ClientListener>(shared_from_this());
+      std::make_shared<ClientListener>(weak_from_this());
   new_temp_client->Init();
   new_temp_client->StartUp(listener);
+#if defined(TESTING)
+  WaitForClientListenerReleaseForTest();
+#endif
 }
 
 void SocketServerPosix::CloseSocket(int socket_fd) {

--- a/debug_router/native/socket/socket_server_api.cc
+++ b/debug_router/native/socket/socket_server_api.cc
@@ -2,12 +2,19 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-#include "debug_router/native/socket/socket_server_type.h"
+#include "debug_router/native/socket/socket_server_api.h"
+
 #ifdef _WIN32
+#include <winsock2.h>
+
 #include "debug_router/native/socket/win/socket_server_win.h"
 #else
+#include <sys/socket.h>
+
 #include "debug_router/native/socket/posix/socket_server_posix.h"
 #endif
+#include <utility>
+
 #include "debug_router/native/core/util.h"
 #include "debug_router/native/thread/debug_router_executor.h"
 
@@ -17,10 +24,16 @@ namespace socket_server {
 std::shared_ptr<SocketServer> SocketServer::CreateSocketServer(
     const std::shared_ptr<SocketServerConnectionListener> &listener) {
 #ifdef _WIN32
-  return std::make_shared<SocketServerWin>(listener);
+  SocketServer *socket_server = new SocketServerWin(listener);
 #else
-  return std::make_shared<SocketServerPosix>(listener);
+  SocketServer *socket_server = new SocketServerPosix(listener);
 #endif
+  return std::shared_ptr<SocketServer>(socket_server, [](SocketServer *server) {
+    // Stop while the dynamic platform object is still fully alive. Its
+    // destructor repeats this idempotently for direct internal construction.
+    server->StopServer();
+    delete server;
+  });
 }
 
 SocketServer::SocketServer(
@@ -52,7 +65,13 @@ bool SocketServer::Send(const std::string &message) {
 
 void SocketServer::HandleOnOpenStatus(std::shared_ptr<UsbClient> client,
                                       int32_t code, const std::string &reason) {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  auto callback = [weak_server, this, client = std::move(client), code,
+                   reason]() {
+    auto keep_alive = weak_server.lock();
+    if (!keep_alive) {
+      return;
+    }
     std::shared_ptr<UsbClient> old_client_;
     bool should_notify = false;
     {
@@ -75,12 +94,18 @@ void SocketServer::HandleOnOpenStatus(std::shared_ptr<UsbClient> client,
         listener->OnStatusChanged(kConnected, code, reason);
       }
     }
-  });
+  };
+  thread::DebugRouterExecutor::GetInstance().Post(std::move(callback));
 }
 
 void SocketServer::HandleOnMessageStatus(std::shared_ptr<UsbClient> client,
                                          const std::string &message) {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  auto callback = [weak_server, this, client = std::move(client), message]() {
+    auto keep_alive = weak_server.lock();
+    if (!keep_alive) {
+      return;
+    }
     bool is_current_client = false;
     {
       std::lock_guard<std::mutex> lock(client_lock_);
@@ -93,13 +118,20 @@ void SocketServer::HandleOnMessageStatus(std::shared_ptr<UsbClient> client,
     if (auto listener = listener_.lock()) {
       listener->OnMessage(message);
     }
-  });
+  };
+  thread::DebugRouterExecutor::GetInstance().Post(std::move(callback));
 }
 
 void SocketServer::HandleOnCloseStatus(std::shared_ptr<UsbClient> client,
                                        ConnectionStatus status, int32_t code,
                                        const std::string &reason) {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  thread::DebugRouterExecutor::GetInstance().Post([weak_server, this, client,
+                                                   status, code, reason]() {
+    auto keep_alive = weak_server.lock();
+    if (!keep_alive) {
+      return;
+    }
     std::shared_ptr<UsbClient> client_to_stop;
     bool should_notify = false;
     // True if this callback tore down a client that had already been
@@ -152,7 +184,13 @@ void SocketServer::HandleOnCloseStatus(std::shared_ptr<UsbClient> client,
 void SocketServer::HandleOnErrorStatus(std::shared_ptr<UsbClient> client,
                                        ConnectionStatus status, int32_t code,
                                        const std::string &reason) {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  thread::DebugRouterExecutor::GetInstance().Post([weak_server, this, client,
+                                                   status, code, reason]() {
+    auto keep_alive = weak_server.lock();
+    if (!keep_alive) {
+      return;
+    }
     std::shared_ptr<UsbClient> client_to_stop;
     bool should_notify = false;
     // True if this callback tore down a client that had already been
@@ -203,29 +241,76 @@ void SocketServer::HandleOnErrorStatus(std::shared_ptr<UsbClient> client,
 }
 
 void SocketServer::NotifyInit(int32_t code, const std::string &info) {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    if (auto listener = listener_.lock()) {
-      listener->OnInit(code, info);
+  uint64_t generation = 0;
+  {
+    std::lock_guard<std::mutex> lock(running_mutex_);
+    generation = listener_generation_;
+    if (listener_should_exit_ || !is_running_.load(std::memory_order_relaxed) ||
+        generation != server_generation_) {
+      return;
     }
-  });
+  }
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  thread::DebugRouterExecutor::GetInstance().Post(
+      [weak_server, generation, code, info]() {
+        auto socket_server = weak_server.lock();
+        if (!socket_server ||
+            !socket_server->IsListenerGenerationActive(generation)) {
+          return;
+        }
+        if (auto listener = socket_server->listener_.lock()) {
+          listener->OnInit(code, info);
+        }
+      });
 }
 
 void SocketServer::setEnableServer(bool enable) {
   LOGI("SocketServer::setEnableServer:" << enable);
-  // notify only when transition from false to true
-  if (!is_running_.exchange(enable, std::memory_order_relaxed) && enable) {
+  if (enable) {
+    StartServer();
+  } else {
+    StopServer();
+  }
+}
+
+void SocketServer::StartServer() {
+  std::lock_guard<std::mutex> operation_lock(server_operation_mutex_);
+  bool should_notify = false;
+  {
+    std::lock_guard<std::mutex> lock(running_mutex_);
+    if (initialized_ && !listen_thread_.joinable()) {
+      listener_should_exit_ = false;
+      listen_thread_ = std::thread(ListenerThreadFunc, this);
+    }
+    if (!is_running_.exchange(true, std::memory_order_relaxed)) {
+      ++server_generation_;
+      should_notify = true;
+    }
+  }
+  if (should_notify) {
     running_condition_.notify_one();
   }
 }
 
-void SocketServer::StartServer() { setEnableServer(true); }
-
 void SocketServer::StopServer() {
+  std::lock_guard<std::mutex> operation_lock(server_operation_mutex_);
   std::shared_ptr<UsbClient> current_client;
   std::shared_ptr<UsbClient> pending_client;
-  setEnableServer(false);
-  // Close socket if it's valid
-  SocketType socket_fd = socket_fd_.load(std::memory_order_acquire);
+  SocketType socket_fd = kInvalidSocket;
+  {
+    std::lock_guard<std::mutex> lock(running_mutex_);
+    is_running_.store(false, std::memory_order_relaxed);
+    listener_should_exit_ = true;
+    ++server_generation_;
+    socket_fd = socket_fd_.load(std::memory_order_acquire);
+  }
+#if defined(TESTING)
+  if (stop_requested_latch_for_test_) {
+    stop_requested_latch_for_test_->CountDown();
+  }
+#endif
+  running_condition_.notify_all();
+
   if (socket_fd != kInvalidSocket) {
 #ifdef _WIN32
     shutdown(socket_fd, SD_BOTH);
@@ -248,17 +333,31 @@ void SocketServer::StopServer() {
   if (pending_client && pending_client != current_client) {
     pending_client->Stop();
   }
+
+  if (listen_thread_.joinable()) {
+    listen_thread_.join();
+  }
 }
 
 void SocketServer::ThreadFunc(std::shared_ptr<SocketServer> socket_server) {
+  // Keep the protected entry point source-compatible. Internal listener
+  // generations use ListenerThreadFunc so the thread does not own the server.
+  ListenerThreadFunc(socket_server.get());
+}
+
+void SocketServer::ListenerThreadFunc(SocketServer *socket_server) {
   int count = 0;
   while (true) {
     {
       std::unique_lock lock(socket_server->running_mutex_);
-      socket_server->running_condition_.wait(lock, [=]() {
-        return socket_server->is_running_.load(std::memory_order_relaxed) ==
-               true;
+      socket_server->running_condition_.wait(lock, [socket_server]() {
+        return socket_server->listener_should_exit_ ||
+               socket_server->is_running_.load(std::memory_order_relaxed);
       });
+      if (socket_server->listener_should_exit_) {
+        return;
+      }
+      socket_server->listener_generation_ = socket_server->server_generation_;
     }
     LOGI("Init start:" << count);
     socket_server->Start();
@@ -267,8 +366,57 @@ void SocketServer::ThreadFunc(std::shared_ptr<SocketServer> socket_server) {
 }
 
 void SocketServer::Init() {
-  std::thread listen_thread(ThreadFunc, shared_from_this());
-  listen_thread.detach();
+  std::lock_guard<std::mutex> operation_lock(server_operation_mutex_);
+  std::lock_guard<std::mutex> lock(running_mutex_);
+  initialized_ = true;
+  if (!listen_thread_.joinable()) {
+    listener_should_exit_ = false;
+    listen_thread_ = std::thread(ListenerThreadFunc, this);
+  }
+}
+
+bool SocketServer::TryPublishSocket(SocketType socket_fd) {
+  std::lock_guard<std::mutex> lock(running_mutex_);
+  if (listener_should_exit_ || !is_running_.load(std::memory_order_relaxed) ||
+      listener_generation_ != server_generation_) {
+    return false;
+  }
+  socket_fd_.store(socket_fd, std::memory_order_release);
+  return true;
+}
+
+bool SocketServer::TryInstallPendingClient(
+    const std::shared_ptr<UsbClient> &client,
+    std::shared_ptr<UsbClient> *old_client) {
+  std::lock_guard<std::mutex> running_lock(running_mutex_);
+  if (listener_should_exit_ || !is_running_.load(std::memory_order_relaxed) ||
+      listener_generation_ != server_generation_) {
+    return false;
+  }
+  std::lock_guard<std::mutex> client_lock(client_lock_);
+  *old_client = temp_usb_client_;
+  temp_usb_client_ = client;
+  return true;
+}
+
+#if defined(TESTING)
+void SocketServer::WaitForClientListenerReleaseForTest() {
+  CountDownLatch *created_latch = client_listener_created_latch_for_test_;
+  CountDownLatch *release_latch = release_client_listener_latch_for_test_;
+  if (created_latch) {
+    created_latch->CountDown();
+  }
+  if (release_latch) {
+    release_latch->Await();
+  }
+}
+#endif
+
+bool SocketServer::IsListenerGenerationActive(uint64_t generation) {
+  std::lock_guard<std::mutex> lock(running_mutex_);
+  return !listener_should_exit_ &&
+         is_running_.load(std::memory_order_relaxed) &&
+         generation == server_generation_;
 }
 
 // close server socket
@@ -283,41 +431,61 @@ void SocketServer::Close() {
 }
 
 void SocketServer::Disconnect() {
-  thread::DebugRouterExecutor::GetInstance().Post([=]() {
-    std::shared_ptr<UsbClient> client_to_stop;
-    {
-      std::lock_guard<std::mutex> lock(client_lock_);
-      client_to_stop = usb_client_;
-      usb_client_ = nullptr;
-      if (temp_usb_client_ == client_to_stop) {
-        temp_usb_client_ = nullptr;
-      }
-    }
-    if (client_to_stop) {
-      LOGI("SocketServerApi Disconnect: stop curr client.");
-      ScheduleClientStop(client_to_stop);
-    }
-  });
+  uint64_t generation = 0;
+  std::shared_ptr<UsbClient> target;
+  if (!SnapshotClientForDisconnect(&generation, &target)) {
+    return;
+  }
+  std::weak_ptr<SocketServer> weak_server = weak_from_this();
+  thread::DebugRouterExecutor::GetInstance().Post(
+      [weak_server, generation, target = std::move(target)]() {
+        auto socket_server = weak_server.lock();
+        if (!socket_server) {
+          return;
+        }
+        std::shared_ptr<UsbClient> client_to_stop =
+            socket_server->TakeClientForDisconnect(generation, target);
+        if (client_to_stop) {
+          LOGI("SocketServerApi Disconnect: stop curr client.");
+          socket_server->ScheduleClientStop(client_to_stop);
+        }
+      });
 }
 
-SocketServer::~SocketServer() {
-  clean_executor_.shutdown();
-  std::shared_ptr<UsbClient> current_client;
-  std::shared_ptr<UsbClient> pending_client;
-  {
-    std::lock_guard<std::mutex> lock(client_lock_);
-    current_client = usb_client_;
-    pending_client = temp_usb_client_;
-    usb_client_ = nullptr;
+bool SocketServer::SnapshotClientForDisconnect(
+    uint64_t *generation, std::shared_ptr<UsbClient> *target) {
+  std::lock_guard<std::mutex> running_lock(running_mutex_);
+  if (listener_should_exit_ || !is_running_.load(std::memory_order_relaxed)) {
+    return false;
+  }
+  std::lock_guard<std::mutex> client_lock(client_lock_);
+  if (!usb_client_) {
+    return false;
+  }
+  *generation = server_generation_;
+  *target = usb_client_;
+  return true;
+}
+
+std::shared_ptr<UsbClient> SocketServer::TakeClientForDisconnect(
+    uint64_t generation, const std::shared_ptr<UsbClient> &target) {
+  std::lock_guard<std::mutex> running_lock(running_mutex_);
+  if (listener_should_exit_ || !is_running_.load(std::memory_order_relaxed) ||
+      generation != server_generation_) {
+    return nullptr;
+  }
+  std::lock_guard<std::mutex> client_lock(client_lock_);
+  if (usb_client_ != target) {
+    return nullptr;
+  }
+  usb_client_ = nullptr;
+  if (temp_usb_client_ == target) {
     temp_usb_client_ = nullptr;
   }
-  if (current_client) {
-    current_client->Stop();
-  }
-  if (pending_client && pending_client != current_client) {
-    pending_client->Stop();
-  }
+  return target;
 }
+
+SocketServer::~SocketServer() { clean_executor_.shutdown(); }
 
 }  // namespace socket_server
 }  // namespace debugrouter

--- a/debug_router/native/socket/socket_server_api.h
+++ b/debug_router/native/socket/socket_server_api.h
@@ -6,6 +6,8 @@
 #define DEBUGROUTER_NATIVE_SOCKET_SOCKET_SERVER_API_H
 
 #include <atomic>
+#include <cstdint>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -57,11 +59,21 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   void StopServer();
 
  protected:
+  // SocketServer is an internal platform abstraction. Callers must use
+  // CreateSocketServer(), whose deleter stops the listener before object
+  // destruction starts. Built-in destructors repeat StopServer() idempotently
+  // for direct internal construction after an explicit stop.
   static void ThreadFunc(std::shared_ptr<SocketServer> socket_server);
 
   virtual void Start() = 0;
   virtual int GetErrorMessage() = 0;
   virtual void CloseSocket(int socket_fd) = 0;
+  bool TryPublishSocket(SocketType socket_fd);
+  bool TryInstallPendingClient(const std::shared_ptr<UsbClient> &client,
+                               std::shared_ptr<UsbClient> *old_client);
+#if defined(TESTING)
+  void WaitForClientListenerReleaseForTest();
+#endif
   void Close();
   void NotifyInit(int32_t code, const std::string &info);
 
@@ -80,15 +92,39 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   std::atomic<SocketType> socket_fd_{kInvalidSocket};
 
  private:
+#if defined(TESTING)
+  friend class SocketServerPosixTestPeer;
+#endif
+
+  static void ListenerThreadFunc(SocketServer *socket_server);
+  bool IsListenerGenerationActive(uint64_t generation);
+  bool SnapshotClientForDisconnect(uint64_t *generation,
+                                   std::shared_ptr<UsbClient> *target);
+  std::shared_ptr<UsbClient> TakeClientForDisconnect(
+      uint64_t generation, const std::shared_ptr<UsbClient> &target);
+
   std::atomic<bool> is_running_{false};
   std::condition_variable running_condition_;
   std::mutex running_mutex_;
+  std::mutex server_operation_mutex_;
+  std::thread listen_thread_;
+  bool initialized_{false};
+  bool listener_should_exit_{false};
+  uint64_t server_generation_{0};
+  uint64_t listener_generation_{0};
+#if defined(TESTING)
+  CountDownLatch *client_listener_created_latch_for_test_{nullptr};
+  CountDownLatch *release_client_listener_latch_for_test_{nullptr};
+  CountDownLatch *stop_requested_latch_for_test_{nullptr};
+#endif
 };
 
 // ClientListener
 class ClientListener : public UsbClientListener {
  public:
   ClientListener(std::shared_ptr<SocketServer> socket_server)
+      : socket_server_(socket_server) {}
+  explicit ClientListener(std::weak_ptr<SocketServer> socket_server)
       : socket_server_(socket_server) {}
 
   virtual ~ClientListener() = default;

--- a/debug_router/native/socket/win/socket_server_win.cc
+++ b/debug_router/native/socket/win/socket_server_win.cc
@@ -7,6 +7,7 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#include <memory>
 #include <mutex>
 
 #include "debug_router/native/core/util.h"
@@ -21,7 +22,7 @@ SocketServerWin::SocketServerWin(
     const std::shared_ptr<SocketServerConnectionListener> &listener)
     : SocketServer(listener) {}
 
-SocketServerWin::~SocketServerWin() { Close(); }
+SocketServerWin::~SocketServerWin() { StopServer(); }
 
 int32_t SocketServerWin::InitSocket() {
   LOGI("SocketServerWin::InitSocket");
@@ -34,7 +35,6 @@ int32_t SocketServerWin::InitSocket() {
   }
 
   const SocketType socket_fd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
-  socket_fd_.store(socket_fd, std::memory_order_release);
   if (socket_fd == kInvalidSocket) {
     LOGE("create socket error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "create socket error");
@@ -60,7 +60,7 @@ int32_t SocketServerWin::InitSocket() {
            GetErrorMessage() == WSAEADDRINUSE);
 
   if (!flag) {
-    Close();
+    CloseSocket(socket_fd);
     LOGE("bind address error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "bind address error");
     return kInvalidPort;
@@ -69,9 +69,13 @@ int32_t SocketServerWin::InitSocket() {
   LOGI("bind port:" << port);
 
   if (listen(socket_fd, kConnectionQueueMaxLength) == SOCKET_ERROR) {
-    Close();
+    CloseSocket(socket_fd);
     LOGE("listen error:" << GetErrorMessage());
     NotifyInit(GetErrorMessage(), "listen error");
+    return kInvalidPort;
+  }
+  if (!TryPublishSocket(socket_fd)) {
+    CloseSocket(socket_fd);
     return kInvalidPort;
   }
   return port;
@@ -93,26 +97,28 @@ void SocketServerWin::Start() {
   LOGI("server socket:" << socket_fd);
   SocketType accept_socket_fd = accept(socket_fd, NULL, NULL);
   if (accept_socket_fd == kInvalidSocket) {
+    const int error = GetErrorMessage();
     Close();
-    LOGE("accept socket error:" << GetErrorMessage());
-    NotifyInit(GetErrorMessage(), "accept socket error");
+    LOGE("accept socket error:" << error);
+    NotifyInit(error, "accept socket error");
     return;
   }
   std::shared_ptr<UsbClient> old_client;
   auto new_client = std::make_shared<UsbClient>(accept_socket_fd);
-  {
-    std::lock_guard<std::mutex> lock(client_lock_);
-    old_client = temp_usb_client_;
-    temp_usb_client_ = new_client;
+  if (!TryInstallPendingClient(new_client, &old_client)) {
+    return;
   }
   if (old_client) {
     LOGI("close last connector, destroy temp_usb_client_.");
     ScheduleClientStop(old_client);
   }
   std::shared_ptr<ClientListener> listener =
-      std::make_shared<ClientListener>(shared_from_this());
+      std::make_shared<ClientListener>(weak_from_this());
   new_client->Init();
   new_client->StartUp(listener);
+#if defined(TESTING)
+  WaitForClientListenerReleaseForTest();
+#endif
 }
 
 void SocketServerWin::CloseSocket(int socket_fd) {

--- a/debug_router/native/test/socket_server_posix_unittest.cc
+++ b/debug_router/native/test/socket_server_posix_unittest.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include "debug_router/native/base/socket_guard.h"
 #include "debug_router/native/socket/count_down_latch.h"
@@ -33,12 +34,60 @@ class SocketServerPosixTestPeer {
     server.socket_fd_.store(socket_fd, std::memory_order_release);
   }
 
-  static void AcceptOnce(SocketServerPosix &server) { server.Start(); }
+  static void AcceptOnce(SocketServerPosix &server) {
+    {
+      std::lock_guard<std::mutex> lock(server.running_mutex_);
+      server.is_running_.store(true, std::memory_order_relaxed);
+      ++server.server_generation_;
+      server.listener_generation_ = server.server_generation_;
+    }
+    server.Start();
+  }
 
   static void SetTemporaryClient(SocketServerPosix &server,
                                  std::shared_ptr<UsbClient> client) {
     std::lock_guard<std::mutex> lock(server.client_lock_);
     server.temp_usb_client_ = std::move(client);
+  }
+
+  static void SetCurrentClient(SocketServerPosix &server,
+                               std::shared_ptr<UsbClient> client) {
+    std::lock_guard<std::mutex> lock(server.client_lock_);
+    server.usb_client_ = std::move(client);
+  }
+
+  static std::shared_ptr<UsbClient> CurrentClient(SocketServerPosix &server) {
+    std::lock_guard<std::mutex> lock(server.client_lock_);
+    return server.usb_client_;
+  }
+
+  static void SetLifecycleLatches(SocketServerPosix &server,
+                                  CountDownLatch *created_latch,
+                                  CountDownLatch *release_latch,
+                                  CountDownLatch *stop_latch) {
+    server.client_listener_created_latch_for_test_ = created_latch;
+    server.release_client_listener_latch_for_test_ = release_latch;
+    server.stop_requested_latch_for_test_ = stop_latch;
+  }
+
+  static void BeginGeneration(SocketServerPosix &server) {
+    std::lock_guard<std::mutex> lock(server.running_mutex_);
+    server.listener_should_exit_ = false;
+    server.is_running_.store(true, std::memory_order_relaxed);
+    ++server.server_generation_;
+    server.listener_generation_ = server.server_generation_;
+  }
+
+  static bool SnapshotClientForDisconnect(SocketServerPosix &server,
+                                          uint64_t *generation,
+                                          std::shared_ptr<UsbClient> *target) {
+    return server.SnapshotClientForDisconnect(generation, target);
+  }
+
+  static std::shared_ptr<UsbClient> TakeClientForDisconnect(
+      SocketServerPosix &server, uint64_t generation,
+      const std::shared_ptr<UsbClient> &target) {
+    return server.TakeClientForDisconnect(generation, target);
   }
 
   static void SubmitClientWork(const std::shared_ptr<UsbClient> &client,
@@ -182,6 +231,72 @@ TEST(SocketServerPosixTestSuite,
 
   EXPECT_TRUE(accepted_before_cleanup);
   EXPECT_TRUE(old_client_weak.expired());
+}
+
+TEST(SocketServerPosixTestSuite,
+     AcceptedClientListenerDoesNotOwnServerDuringTeardown) {
+  auto listener = std::make_shared<NoopListener>();
+  CountDownLatch client_listener_created(1);
+  CountDownLatch release_client_listener(1);
+  CountDownLatch stop_requested(1);
+  auto base_server = SocketServer::CreateSocketServer(listener);
+  auto server = std::static_pointer_cast<SocketServerPosix>(base_server);
+  base_server.reset();
+  std::weak_ptr<SocketServerPosix> weak_server = server;
+
+  uint16_t port = 0;
+  const int listener_socket = CreateLoopbackListener(port);
+  ASSERT_GE(listener_socket, 0);
+  SocketServerPosixTestPeer::AdoptListeningSocket(*server, listener_socket);
+
+  SocketServerPosixTestPeer::SetLifecycleLatches(
+      *server, &client_listener_created, &release_client_listener,
+      &stop_requested);
+
+  server->Init();
+  server->StartServer();
+  const int peer_socket = ConnectToPort(port);
+  ASSERT_GE(peer_socket, 0);
+  base::SocketGuard peer(peer_socket);
+  client_listener_created.Await();
+
+  EXPECT_EQ(server.use_count(), 1);
+  if (server.use_count() != 1) {
+    release_client_listener.CountDown();
+    server->StopServer();
+    return;
+  }
+
+  std::thread reset_thread(
+      [owned_server = std::move(server)]() mutable { owned_server.reset(); });
+  stop_requested.Await();
+  release_client_listener.CountDown();
+  reset_thread.join();
+
+  EXPECT_TRUE(weak_server.expired());
+}
+
+TEST(SocketServerPosixTestSuite,
+     StaleDisconnectDoesNotClearClientFromNewGeneration) {
+  auto listener = std::make_shared<NoopListener>();
+  auto server = std::make_shared<SocketServerPosix>(listener);
+  auto old_client = std::make_shared<UsbClient>(kInvalidSocket);
+
+  SocketServerPosixTestPeer::BeginGeneration(*server);
+  SocketServerPosixTestPeer::SetCurrentClient(*server, old_client);
+  uint64_t old_generation = 0;
+  std::shared_ptr<UsbClient> old_target;
+  ASSERT_TRUE(SocketServerPosixTestPeer::SnapshotClientForDisconnect(
+      *server, &old_generation, &old_target));
+
+  SocketServerPosixTestPeer::BeginGeneration(*server);
+  auto new_client = std::make_shared<UsbClient>(kInvalidSocket);
+  SocketServerPosixTestPeer::SetCurrentClient(*server, new_client);
+
+  EXPECT_EQ(SocketServerPosixTestPeer::TakeClientForDisconnect(
+                *server, old_generation, old_target),
+            nullptr);
+  EXPECT_EQ(SocketServerPosixTestPeer::CurrentClient(*server), new_client);
 }
 
 }  // namespace

--- a/debug_router/native/test/socket_server_smoke_unittest.cc
+++ b/debug_router/native/test/socket_server_smoke_unittest.cc
@@ -2,9 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
 
+#include "debug_router/native/socket/count_down_latch.h"
 #include "debug_router/native/socket/socket_server_api.h"
 #include "gtest/gtest.h"
 
@@ -20,6 +23,57 @@ class NoopSocketServerListener final : public SocketServerConnectionListener {
   void OnMessage(const std::string&) override {}
 };
 
+class BarrierSocketServer final : public SocketServer {
+ public:
+  explicit BarrierSocketServer(
+      const std::shared_ptr<SocketServerConnectionListener>& listener)
+      : SocketServer(listener) {}
+  ~BarrierSocketServer() override { StopServer(); }
+
+  void WaitUntilStartEntered(int generation) {
+    StartEntered(generation).Await();
+  }
+  void WaitUntilClose(int generation) { CloseCalled(generation).Await(); }
+  void ReleaseStart(int generation) { ReleaseLatch(generation).CountDown(); }
+  SocketType PublishedSocket() const {
+    return socket_fd_.load(std::memory_order_acquire);
+  }
+
+ private:
+  void Start() override {
+    const int generation = start_count_.fetch_add(1, std::memory_order_relaxed);
+    StartEntered(generation).CountDown();
+    ReleaseLatch(generation).Await();
+    TryPublishSocket(123 + generation);
+  }
+
+  int GetErrorMessage() override { return 0; }
+
+  void CloseSocket(int) override {
+    const int generation = close_count_.fetch_add(1, std::memory_order_relaxed);
+    CloseCalled(generation).CountDown();
+  }
+
+  CountDownLatch& StartEntered(int generation) {
+    return generation == 0 ? first_start_entered_ : second_start_entered_;
+  }
+  CountDownLatch& ReleaseLatch(int generation) {
+    return generation == 0 ? release_first_start_ : release_second_start_;
+  }
+  CountDownLatch& CloseCalled(int generation) {
+    return generation == 0 ? first_close_called_ : second_close_called_;
+  }
+
+  std::atomic<int> start_count_{0};
+  std::atomic<int> close_count_{0};
+  CountDownLatch first_start_entered_{1};
+  CountDownLatch second_start_entered_{1};
+  CountDownLatch release_first_start_{1};
+  CountDownLatch release_second_start_{1};
+  CountDownLatch first_close_called_{1};
+  CountDownLatch second_close_called_{1};
+};
+
 TEST(SocketServerSmokeTestSuite,
      ConstructAndImmediateDestroyWithoutStartDoesNotCrash) {
   ASSERT_EXIT(
@@ -30,6 +84,48 @@ TEST(SocketServerSmokeTestSuite,
         _exit(0);
       },
       ::testing::ExitedWithCode(0), "");
+}
+
+TEST(SocketServerSmokeTestSuite,
+     StopCompletesAndRejectsPreStopListenerGeneration) {
+  auto listener = std::make_shared<NoopSocketServerListener>();
+  auto server = std::make_shared<BarrierSocketServer>(listener);
+  std::weak_ptr<SocketServer> weak_server = server;
+
+  server->Init();
+  server->StartServer();
+  server->WaitUntilStartEntered(0);
+  std::thread stop_thread(&SocketServer::StopServer, server);
+  server->WaitUntilClose(0);
+  server->ReleaseStart(0);
+  stop_thread.join();
+
+  EXPECT_EQ(server->PublishedSocket(), kInvalidSocket);
+  server.reset();
+
+  EXPECT_TRUE(weak_server.expired());
+}
+
+TEST(SocketServerSmokeTestSuite, StartCreatesNewListenerAfterStop) {
+  auto listener = std::make_shared<NoopSocketServerListener>();
+  auto server = std::make_shared<BarrierSocketServer>(listener);
+  server->Init();
+
+  server->StartServer();
+  server->WaitUntilStartEntered(0);
+  std::thread first_stop(&SocketServer::StopServer, server);
+  server->WaitUntilClose(0);
+  server->ReleaseStart(0);
+  first_stop.join();
+
+  server->StartServer();
+  server->WaitUntilStartEntered(1);
+  std::thread second_stop(&SocketServer::StopServer, server);
+  server->WaitUntilClose(1);
+  server->ReleaseStart(1);
+  second_stop.join();
+
+  EXPECT_EQ(server->PublishedSocket(), kInvalidSocket);
 }
 
 }  // namespace

--- a/debug_router/native/test/usb_reconnect_race_unittest.cc
+++ b/debug_router/native/test/usb_reconnect_race_unittest.cc
@@ -269,7 +269,6 @@ class UsbReconnectIntegrationTest : public testing::Test {
   void TearDown() override {
     if (server_) {
       server_->StopServer();
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
       server_.reset();
     }
   }


### PR DESCRIPTION
## Summary

- own and join the native socket listener thread during shutdown
- invalidate stopped listener generations before they can publish a socket or accepted client
- make disconnect callbacks generation- and client-qualified
- avoid retaining the server from accepted clients and queued callbacks
- replace the teardown sleep with deterministic lifecycle tests

## Test plan

- `buildtools/ninja/ninja -C out/Default example_unittest debug_router_core`
- `out/Default/example_unittest` (47/47)
- lifecycle regression tests repeated 1000 times
- `git diff --check`
- clang-format dry run

Fixes #178