### PR TITLE
[BugFix] Complete partial USB socket writes

### DIFF
--- a/debug_router/native/base/socket_guard.h
+++ b/debug_router/native/base/socket_guard.h
@@ -55,6 +55,50 @@ inline SocketSendResult SendNoSigPipe(SocketType sock, const void* buffer,
 #endif
 }
 
+namespace internal {
+
+inline bool IsSocketSendInterrupted() {
+#if defined(_WIN32)
+  return WSAGetLastError() == WSAEINTR;
+#else
+  return errno == EINTR;
+#endif
+}
+
+template <typename SendOperation>
+bool SendAllWith(const void* buffer, size_t length,
+                 SendOperation send_operation) {
+  const char* next = static_cast<const char*>(buffer);
+  size_t remaining = length;
+  while (remaining > 0) {
+    const SocketSendResult result = send_operation(next, remaining);
+    if (result > 0) {
+      const size_t sent = static_cast<size_t>(result);
+      if (sent > remaining) {
+        return false;
+      }
+      next += sent;
+      remaining -= sent;
+      continue;
+    }
+    if (result < 0 && IsSocketSendInterrupted()) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+inline bool SendAllNoSigPipe(SocketType sock, const void* buffer,
+                             size_t length) {
+  return SendAllWith(buffer, length,
+                     [sock](const void* remaining, size_t remaining_length) {
+                       return SendNoSigPipe(sock, remaining, remaining_length);
+                     });
+}
+
+}  // namespace internal
+
 class SocketGuard {
  public:
   SocketType Get() {

--- a/debug_router/native/socket/usb_client.cc
+++ b/debug_router/native/socket/usb_client.cc
@@ -439,8 +439,9 @@ void UsbClient::WriteMessage() {
       }
       std::string result_message;
       WrapHeader(message, result_message);
-      if (base::SendNoSigPipe(socket_guard_.Get(), result_message.c_str(),
-                              result_message.size()) == -1) {
+      if (!base::internal::SendAllNoSigPipe(socket_guard_.Get(),
+                                            result_message.c_str(),
+                                            result_message.size())) {
         LOGE("send error: " << GetErrorMessage() << " message:" << message);
         BeginTransportShutdown();
         NotifyErrorOnce(GetErrorMessage(),

--- a/debug_router/native/test/socket_util_unittest.cc
+++ b/debug_router/native/test/socket_util_unittest.cc
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "debug_router/native/base/socket_guard.h"
 #include "debug_router/native/core/debug_router_core.h"
@@ -25,6 +26,22 @@
 #endif
 
 namespace {
+
+void SetInterruptedSocketError() {
+#if defined(_WIN32)
+  WSASetLastError(WSAEINTR);
+#else
+  errno = EINTR;
+#endif
+}
+
+void SetFatalSocketError() {
+#if defined(_WIN32)
+  WSASetLastError(WSAECONNRESET);
+#else
+  errno = EIO;
+#endif
+}
 
 #ifndef _WIN32
 std::set<int32_t> ScanOccupiedDebugRouterPorts() {
@@ -168,6 +185,75 @@ TEST(SocketUtilTestSuite, TestCheckHeader) {
 
   EXPECT_EQ(true, debugrouter::util::CheckHeaderThreeBytes(header));
   EXPECT_EQ(true, debugrouter::util::CheckHeaderFourthByte(header, 27));
+}
+
+TEST(SocketUtilTestSuite, SendAllWithCompletesPositivePartialWrites) {
+  const std::string message = "complete this frame";
+  std::string sent;
+  std::vector<size_t> remaining_lengths;
+  size_t call_count = 0;
+
+  const bool result = debugrouter::base::internal::SendAllWith(
+      message.data(), message.size(),
+      [&](const void* buffer, size_t length) -> SocketSendResult {
+        EXPECT_EQ(static_cast<const char*>(buffer),
+                  message.data() + sent.size());
+        remaining_lengths.push_back(length);
+        const size_t written = call_count++ == 0 ? 3
+                               : call_count == 2 ? 5
+                                                 : length;
+        sent.append(static_cast<const char*>(buffer), written);
+        return static_cast<SocketSendResult>(written);
+      });
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(sent, message);
+  EXPECT_EQ(remaining_lengths,
+            std::vector<size_t>(
+                {message.size(), message.size() - 3, message.size() - 8}));
+}
+
+TEST(SocketUtilTestSuite, SendAllWithRetriesInterruptedWrite) {
+  const std::string message = "message";
+  size_t call_count = 0;
+
+  const bool result = debugrouter::base::internal::SendAllWith(
+      message.data(), message.size(),
+      [&](const void*, size_t length) -> SocketSendResult {
+        if (call_count++ == 0) {
+          SetInterruptedSocketError();
+          return -1;
+        }
+        return static_cast<SocketSendResult>(length);
+      });
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(call_count, 2u);
+}
+
+TEST(SocketUtilTestSuite, SendAllWithStopsOnZeroWrite) {
+  size_t call_count = 0;
+  const bool result = debugrouter::base::internal::SendAllWith(
+      "message", 7, [&](const void*, size_t) -> SocketSendResult {
+        ++call_count;
+        return 0;
+      });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(call_count, 1u);
+}
+
+TEST(SocketUtilTestSuite, SendAllWithStopsOnFatalWriteError) {
+  size_t call_count = 0;
+  const bool result = debugrouter::base::internal::SendAllWith(
+      "message", 7, [&](const void*, size_t) -> SocketSendResult {
+        ++call_count;
+        SetFatalSocketError();
+        return -1;
+      });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(call_count, 1u);
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
## Summary

- complete positive partial writes in the framed native USB transport
- preserve the existing `SendNoSigPipe` API and SIGPIPE behavior
- stop on zero or fatal writes without reconnecting or replaying messages

## Tests

- native unit tests: 47/47
- deterministic partial-write, interrupted-write, zero-write, and fatal-write coverage
- `debug_router_core` build
- clang-format and diff checks

Closes #183