### PR TITLE
[Feature][Multiplexer] Extract physical connector layer

### DIFF
--- a/agents/PhysicalConnector Architecture Design.md
+++ b/agents/PhysicalConnector Architecture Design.md
@@ -1,0 +1,126 @@
+# PhysicalConnector Architecture Design
+
+## Overview
+
+`PhysicalConnector` is the DebugRouter Daemon component that manages real
+devices and the USB DebugRouter runtimes running on them. It is a new boundary
+introduced by the Multiplexer architecture; the legacy architecture had no
+equivalent standalone component.
+
+The legacy `DebugRouterConnector` was designed for a single Connector process,
+so it could own both the caller-facing API and the physical connections. In the
+Multiplexer architecture, multiple Connector facades share one Daemon. Real
+devices cannot be owned independently by every facade: doing so would duplicate
+device discovery, start competing watchers, and create conflicting runtime
+connections.
+
+`PhysicalConnector` gives these physical resources one owner inside the Daemon.
+It also separates device-specific connection work from the Host's daemon-wide
+coordination and routing policy.
+
+## Legacy Architecture
+
+In the legacy architecture, `DebugRouterConnector` directly owned the public
+API, WebSocket and routing behavior, multi-open coordination, and physical
+connections.
+
+```mermaid
+flowchart TB
+  Legacy["DebugRouterConnector"]
+  PhysicalJunction((" "))
+  WebSocket["WebSocket server and routing"]
+  MultiOpen["Multi-open coordination"]
+  Managers["Device managers"]
+  Devices["Real devices"]
+  Clients["Real USB runtimes"]
+
+  Legacy --> WebSocket
+  Legacy --> MultiOpen
+  Legacy --- PhysicalJunction
+  PhysicalJunction --> Managers
+  PhysicalJunction --> Devices
+  PhysicalJunction --> Clients
+```
+
+Because the physical connection lifecycle belonged to the Connector itself,
+this structure could not safely represent several callers sharing the same
+devices.
+
+## Multiplexer Architecture
+
+Multiplexer gives each kind of responsibility a separate owner: Connector
+facades represent callers, the Daemon Host coordinates shared behavior, and
+`PhysicalConnector` manages the real physical resources.
+
+```mermaid
+flowchart LR
+  Facade1["Connector facade 1"]
+  Facade2["Connector facade 2"]
+  Facade3["Connector facade 3"]
+
+  subgraph Daemon["DebugRouter Daemon"]
+    Host["Daemon Host"]
+    WebSocket["WebSocket controller"]
+    MultiOpen["Multi-open ownership"]
+    Physical["PhysicalConnector"]
+    Managers["Device managers"]
+    Devices["Real devices"]
+    Clients["Real USB runtimes"]
+
+    Host --> WebSocket
+    Host --> MultiOpen
+    Host --> Physical
+    Physical --> Managers
+    Physical --> Devices
+    Physical --> Clients
+  end
+
+  Facade1 -->|Control RPC| Host
+  Facade2 -->|Control RPC| Host
+  Facade3 -->|Control RPC| Host
+```
+
+| Component | Role |
+| --- | --- |
+| Connector facade | Exposes the public API and keeps state local to one caller. |
+| Daemon Host | Coordinates all callers and owns routing, WebSocket, ownership, and recovery policy. |
+| PhysicalConnector | Discovers devices and owns the real Device and USB runtime connections. |
+
+A Connector facade never accesses a real Device or `UsbClient` directly. It
+sends a control request to the Host. The Host decides whether the requested
+shared operation should run, then delegates the physical action to
+`PhysicalConnector` and distributes the resulting state to callers.
+
+## PhysicalConnector Boundary
+
+`PhysicalConnector` is responsible for:
+
+- creating platform device managers and discovering devices;
+- owning the Daemon's real Device and `UsbClient` objects;
+- starting and stopping physical runtime watchers;
+- reporting physical connection, disconnection, and message events to the Host;
+- querying and closing physical resources on behalf of the Host.
+
+It is intentionally not responsible for:
+
+- public Connector APIs or caller-local state;
+- WebSocket lifecycle or cross-connection message routing;
+- multi-open ownership, daemon recovery, or other global policy.
+
+## Why It Is Separate from the Host
+
+The Host needs a global view of all callers and connections, while physical
+device access is platform-specific implementation work. Keeping
+`PhysicalConnector` separate provides three benefits:
+
+- **Single ownership:** one Daemon component owns each real device and runtime.
+- **Clear policy boundary:** the Host decides **whether** an operation should
+  happen; `PhysicalConnector` knows **how** to perform it.
+- **Platform isolation:** Android, iOS, Harmony, desktop, and network discovery
+  details do not leak into routing and ownership logic.
+
+The result is a small physical resource layer that the Host can coordinate
+without becoming coupled to each platform's connection implementation.
+
+For the complete Multiplexer architecture, see
+[`DebugRouter Multiplexer Technical Design.md`](./DebugRouter%20Multiplexer%20Technical%20Design.md).

--- a/debug_router_connector/package.json
+++ b/debug_router_connector/package.json
@@ -12,7 +12,7 @@
     "start": "node bin/driver.js start",
     "build": "rm -rf dist && bash ./scripts/build.sh",
     "types": "rm -rf lib && rm -rf typings && tsc -p tsconfig.prod.json",
-    "test:multiplexer": "npm run build && mocha \"../test/unit/multiplexer/**/*.test.js\"",
+    "test:multiplexer": "npm run build && mocha \"../test/unit/multiplexer/**/*.test.js\" \"../test/unit/physical/**/*.test.js\"",
     "format": "prettier --write ."
   },
   "keywords": [

--- a/debug_router_connector/src/physical/MonitorUtils.ts
+++ b/debug_router_connector/src/physical/MonitorUtils.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import AndroidDevice from "../device/android/AndroidDevice";
+import HarmonyDevice from "../device/Harmony/HarmonyDevice";
+import { BaseDevice } from "../device/BaseDevice";
+import LinuxDevice from "../device/desktop/LinuxDevice";
+import MacDevice from "../device/desktop/MacDevice";
+import WindowsDevice from "../device/desktop/WindowsDevice";
+import iOSDevice from "../device/ios/iOSDevice";
+import NetworkDevice from "../device/network/NetworkDevice";
+import { getDriverReportService } from "../report/interface/DriverReportService";
+import { UsbClient } from "../usb/Client";
+
+let deviceTimeMap: Map<string, number> = new Map();
+let clientTimeMap: Map<number, number> = new Map();
+
+export function setDeviceTimeMap(device: BaseDevice) {
+  deviceTimeMap.set(device.info.serial, new Date().getTime());
+  getDriverReportService()?.report("register_new_device", null, {
+    serial: device.info.serial,
+    deviceType: getDeviceType(device),
+  });
+}
+
+export function monitorUnregisterDevice(device: BaseDevice, retryTime: number) {
+  const currentTime = new Date().getTime();
+  const deviceTime = deviceTimeMap.get(device.info.serial);
+  if (deviceTime && currentTime - deviceTime < retryTime) {
+    getDriverReportService()?.report("quick_lose_device", null, {
+      curTime: currentTime,
+      serial: device.info.serial,
+      dur: currentTime - deviceTime,
+      deviceType: getDeviceType(device),
+    });
+    deviceTimeMap.delete(device.info.serial);
+  }
+}
+
+// add harmony device type check
+function getDeviceType(device: BaseDevice): string {
+  if (device instanceof AndroidDevice) {
+    return "Android";
+  }
+  if (device instanceof iOSDevice) {
+    return "iOS";
+  }
+  if (device instanceof HarmonyDevice) {
+    return "Harmony";
+  }
+  if (device instanceof MacDevice) {
+    return "Mac";
+  }
+  if (device instanceof WindowsDevice) {
+    return "Windows";
+  }
+  if (device instanceof LinuxDevice) {
+    return "Linux";
+  }
+  if (device instanceof NetworkDevice) {
+    return "Network";
+  }
+  return "Unknown";
+}
+
+export function setClientTimeMap(client: UsbClient) {
+  clientTimeMap.set(client.clientId(), new Date().getTime());
+  getDriverReportService()?.report("register_new_client", null, {
+    client: JSON.stringify(client.info.query?.raw_info) ?? "unknown",
+  });
+}
+
+// move the position of delete clientTimeMap after check clientTime
+// to ensure clientTimeMap state in sync
+export function monitorUnregisterClient(client: UsbClient, retryTime: number) {
+  const currentTime = new Date().getTime();
+  const clientTime = clientTimeMap.get(client.clientId());
+  clientTimeMap.delete(client.clientId());
+  if (clientTime && currentTime - clientTime < retryTime) {
+    getDriverReportService()?.report("quick_lose_client", null, {
+      curTime: currentTime,
+      dur: currentTime - clientTime,
+      client: JSON.stringify(client.info.query?.raw_info) ?? "unknown",
+    });
+  }
+}

--- a/debug_router_connector/src/physical/PhysicalConnector.ts
+++ b/debug_router_connector/src/physical/PhysicalConnector.ts
@@ -1,0 +1,520 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { EventEmitter } from "events";
+import { UsbClient } from "../usb/Client";
+import { AndroidDeviceManager } from "../device/android/AndroidDeviceManager";
+import { BaseDevice } from "../device/BaseDevice";
+import AndroidDevice from "../device/android/AndroidDevice";
+import { DeviceManager } from "../device/DeviceManager";
+import NetworkDeviceManager from "../device/network/NetworkDeviceManager";
+import DesktopDeviceManager from "../device/desktop/DesktopDeviceManager";
+import iOSDeviceManager from "../device/ios/iOSDeviceManager";
+import HarmonyDeviceManager from "../device/Harmony/HarmonyDeviceManager";
+import { defaultLogger } from "../utils/logger";
+import { getDriverReportService } from "../report/interface/DriverReportService";
+import type { DebugRouterConnector } from "../connector/DebugRouterConnector";
+import { PhysicalConnectorEvent } from "../utils/type";
+import {
+  monitorUnregisterClient,
+  monitorUnregisterDevice,
+  setClientTimeMap,
+  setDeviceTimeMap,
+} from "./MonitorUtils";
+import type { ConnectionTraceRecorder } from "../trace/ConnectionTraceRecorder";
+
+export type PhysicalConnectorOption = {
+  manualConnect?: boolean;
+  enableAndroid?: boolean;
+  enableIOS?: boolean;
+  enableHarmony?: boolean;
+  enableDesktop?: boolean;
+  enableNetworkDevice?: boolean;
+  adbHostPort?: {
+    host?: string;
+    port?: number;
+  };
+  hdcHostPort?: {
+    host?: string;
+    port?: number;
+  };
+  usbConnectOpt?: {
+    retryTime: number;
+  };
+  networkDeviceOpt?: {
+    ip: string;
+    // a network device can have multi debugger clients
+    port: number[];
+  };
+  traceRecorder?: ConnectionTraceRecorder | null;
+};
+
+export class PhysicalConnector {
+  private readonly events = new EventEmitter();
+  readonly devices = new Map<string, BaseDevice>();
+  readonly usbClients = new Map<number, UsbClient>();
+  private nextClientId: number = 0;
+  private enableAndroid: boolean;
+  private enableIOS: boolean;
+  private enableHarmony: boolean;
+  private enableDesktop: boolean;
+  private readonly enableNetworkDevice: boolean;
+  public readonly traceRecorder: ConnectionTraceRecorder | null = null;
+  private readonly networkDeviceOpt:
+    | {
+        ip: string;
+        port: number[];
+      }
+    | undefined;
+  readonly adbOption: any;
+  readonly hdcOption: any;
+  readonly usbConnectOpt: {
+    retryTime: number;
+  };
+  private closed: boolean = false;
+  private devicesManager: Set<DeviceManager>;
+
+  constructor(
+    option: PhysicalConnectorOption = {
+      manualConnect: false,
+      enableAndroid: true,
+      enableIOS: true,
+      enableHarmony: true,
+      enableDesktop: false,
+      enableNetworkDevice: false,
+      traceRecorder: null,
+    },
+  ) {
+    getDriverReportService()?.init(option.manualConnect);
+    const msg = "PhysicalConnectorOption:" + JSON.stringify(option);
+    defaultLogger.debug(msg);
+    getDriverReportService()?.report(
+      "PhysicalConnectorInit",
+      {},
+      { option: msg },
+    );
+    if (!option.manualConnect) {
+      getDriverReportService()?.report(
+        "PhysicalConnectorInitOfNoManualConnect",
+        {},
+        { option: msg },
+      );
+    }
+    this.enableAndroid = option.enableAndroid ?? true;
+    this.adbOption = option.adbHostPort;
+    // add win32 support
+    this.enableIOS =
+      process.platform === "darwin" || process.platform === "win32"
+        ? option.enableIOS ?? true
+        : false;
+    this.enableHarmony = option.enableHarmony ?? true;
+    this.hdcOption = option.hdcHostPort;
+    this.enableDesktop = option.enableDesktop ?? false;
+    this.enableNetworkDevice = option.enableNetworkDevice ?? false;
+    if (this.enableNetworkDevice) {
+      this.networkDeviceOpt = option.networkDeviceOpt;
+    }
+    this.usbConnectOpt = option.usbConnectOpt ?? {
+      retryTime: 3000,
+    };
+    if (this.usbConnectOpt.retryTime < 3000) {
+      this.usbConnectOpt.retryTime = 3000;
+    }
+    this.setOptionByEnv();
+    this.traceRecorder = option.traceRecorder ?? null;
+    this.devicesManager = new Set<DeviceManager>();
+    // Now DebugRouterConnector is still using the legacy logic right now,
+    // and devicesManager only accepts a DebugRouterConnector object,
+    // so `legacyDriver` is a temporary workaround to keep the project buildable.
+    // After mux is fully integrated, devicesManager will accept a physicalConnector
+    // and we’ll be able to pass `this` instead of `legacyDriver` directly here.
+    const legacyDriver = (this as unknown) as DebugRouterConnector;
+    if (this.enableAndroid) {
+      this.devicesManager.add(
+        new AndroidDeviceManager(legacyDriver, this.adbOption),
+      );
+    }
+    if (this.enableIOS) {
+      this.devicesManager.add(new iOSDeviceManager(legacyDriver));
+    }
+    if (this.enableHarmony) {
+      this.devicesManager.add(
+        new HarmonyDeviceManager(legacyDriver, this.hdcOption),
+      );
+    }
+    if (this.enableDesktop) {
+      this.devicesManager.add(new DesktopDeviceManager(legacyDriver));
+    }
+    if (this.enableNetworkDevice) {
+      if (this.networkDeviceOpt) {
+        // NetWorkDevices use ip as their serial.
+        this.devicesManager.add(
+          new NetworkDeviceManager(legacyDriver, this.networkDeviceOpt),
+        );
+      } else {
+        getDriverReportService()?.report("network_connect_error", null, {
+          msg: "networkDeviceOpt == undefined",
+          stage: "device",
+        });
+        defaultLogger.error("networkDeviceOpt == undefined");
+      }
+    }
+  }
+
+  // functions Migrated from DebugRouterConnector， not modified
+
+  disableAllClients() {
+    defaultLogger.info("disableAllClients");
+    // close usb autoConnect
+    this.devices.forEach((device) => {
+      device.stopWatchClient();
+    });
+    this.getAllUsbClients().forEach((client) => {
+      client.close();
+    });
+  }
+
+  async connectDevices(
+    timeout: number = -1,
+    serial: string | null = null,
+  ): Promise<BaseDevice[]> {
+    await this.startDeviceListeners();
+    return this.getDevices(timeout, serial);
+  }
+
+  private async startDeviceListeners() {
+    const asyncDeviceListenersPromises: Array<Promise<void>> = [];
+    for (const deviceManager of this.devicesManager) {
+      asyncDeviceListenersPromises.push(
+        deviceManager.watchDevices().catch((e) => {
+          getDriverReportService()?.report("device_connect_error", null, {
+            msg: "watchDevices error:" + e?.message,
+            stage: "device",
+          });
+          throw e;
+        }),
+      );
+    }
+    await Promise.all(asyncDeviceListenersPromises);
+  }
+
+  on<Event extends keyof PhysicalConnectorEvent>(
+    event: Event,
+    callback: (payload: PhysicalConnectorEvent[Event]) => void,
+  ): void {
+    this.events.on(event, callback);
+  }
+
+  off<Event extends keyof PhysicalConnectorEvent>(
+    event: Event,
+    callback: (payload: PhysicalConnectorEvent[Event]) => void,
+  ): void {
+    this.events.off(event, callback);
+  }
+
+  unregisterDevice(serial: string) {
+    const device = this.devices.get(serial);
+    if (!device) {
+      defaultLogger.debug(
+        "unregisterDevice warning: no existed device:" + serial,
+      );
+      return;
+    }
+    defaultLogger.debug("unregisterDevice:" + serial);
+    this.traceRecorder?.recordDeviceUnregistered(serial, {
+      os: device.info.os,
+      title: device.info.title,
+    });
+    this.devices.delete(serial);
+    device.disConnect(); // we'll only destroy upon replacement
+    this.emit("device-disconnected", device);
+    monitorUnregisterDevice(device, this.usbConnectOpt.retryTime);
+  }
+
+  getDevices(
+    timeout: number = -1,
+    serial: string | null = null,
+  ): Promise<BaseDevice[]> {
+    return new Promise((resolve) => {
+      if (timeout < 0) {
+        resolve(this.findDevice(serial));
+      } else {
+        const deviceCallback = (device: BaseDevice) => {
+          if (device.serial === serial) {
+            resolve([device]);
+            this.off("device-connected", deviceCallback);
+          }
+        };
+        if (serial !== null) {
+          const targetDevices = this.findDevice(serial);
+          if (targetDevices.length > 0) {
+            resolve(targetDevices);
+            return;
+          }
+          this.on("device-connected", deviceCallback);
+        }
+        setTimeout(() => {
+          this.off("device-connected", deviceCallback);
+          resolve(this.findDevice(serial));
+        }, timeout);
+      }
+    });
+  }
+
+  private findDevice(serial: string | null): BaseDevice[] {
+    let targetDevices = Array.from(this.devices.values());
+    if (serial === null) {
+      return targetDevices;
+    }
+    targetDevices = targetDevices.filter((device) => {
+      return device.serial === serial;
+    });
+    return targetDevices;
+  }
+
+  getAllUsbClients(): UsbClient[] {
+    const clients = new Array();
+    this.usbClients.forEach((value, key) => {
+      clients.push(value);
+    });
+    return clients;
+  }
+
+  getDeviceUsbClients(
+    deviceId: string,
+    timeout: number = -1,
+    clientName: string | null = null,
+  ): Promise<UsbClient[]> {
+    return new Promise((resolve) => {
+      if (!this.devices.has(deviceId)) {
+        defaultLogger.debug("getDeviceUsbClients: has" + deviceId);
+        resolve([]);
+      }
+      if (timeout < 0) {
+        let clients = Array.from(this.usbClients.values());
+        clients = clients.filter((client) => {
+          return client.deviceId() === deviceId;
+        });
+        resolve(this.findUsbClient(clientName, clients));
+      } else {
+        const clientCallback = (client: UsbClient) => {
+          if (client.deviceId() !== deviceId) {
+            return;
+          }
+          if (this.isTargetClient(client, clientName)) {
+            resolve([client]);
+            this.off("client-connected", clientCallback);
+          }
+        };
+        if (clientName != null) {
+          const targetClients = this.findUsbClient(
+            clientName,
+            Array.from(this.usbClients.values()),
+          );
+          if (targetClients.length > 0) {
+            resolve(targetClients);
+            return;
+          }
+          this.on("client-connected", clientCallback);
+        }
+        setTimeout(() => {
+          this.off("client-connected", clientCallback);
+          let clients = Array.from(this.usbClients.values());
+          clients = clients.filter((client) => {
+            return client.deviceId() === deviceId;
+          });
+          resolve(this.findUsbClient(clientName, clients));
+        }, timeout);
+      }
+    });
+  }
+
+  private findUsbClient(
+    clientName: string | null,
+    clients: UsbClient[],
+  ): UsbClient[] {
+    if (clientName === null) {
+      return clients;
+    }
+    const targetClients = clients.filter((client) => {
+      return this.isTargetClient(client, clientName);
+    });
+    return targetClients;
+  }
+
+  private isTargetClient(client: UsbClient, clientName: string | null) {
+    if (clientName == null) {
+      return false;
+    }
+    if (
+      client?.info?.query?.os === "Android" &&
+      client.info.query.raw_info?.AppProcessName === clientName
+    ) {
+      return true;
+    }
+    if (
+      client?.info?.query?.device_model?.indexOf("iPhone") !== -1 &&
+      client.info.query.raw_info?.App === clientName
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  private setOptionByEnv() {
+    if (process.env.DriverEnableAndroid === "false") {
+      this.enableAndroid = false;
+      defaultLogger.warn("set DriverEnableAndroid === false");
+    }
+    if (process.env.DriverEnableIOS === "false") {
+      this.enableIOS = false;
+      defaultLogger.warn("set DriverEnableIOS === false");
+    }
+    if (process.env.DriverEnableDesktop === "false") {
+      this.enableDesktop = false;
+      defaultLogger.warn("set DriverEnableDesktop === false");
+    }
+  }
+
+  // ======================================
+
+  // functions change a little bit
+
+  createClientId(): number {
+    if (this.nextClientId > 4294967294) {
+      defaultLogger.error("createClientId: clientId overflow...but how?"); // This should never happen in normal usage. There must be a bug.
+      return -1;
+    }
+    return ++this.nextClientId;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    // remove multiOpenMonitor part & wss part
+    this.disableAllClients();
+  }
+
+  regiserUsbClient(client: UsbClient) {
+    defaultLogger.debug(
+      "regiserUsbClient:" + " info:" + JSON.stringify(client.info),
+    );
+    const existing = this.usbClients.get(client.clientId());
+    if (existing) {
+      defaultLogger.debug("regiserUsbClient: has exist:" + client.clientId());
+      return;
+    }
+    // register new client
+    this.usbClients.set(client.clientId(), client);
+    this.emit("client-connected", client);
+    this.emit("app-client-connected", client);
+    // remove wss.sendClientList
+    setClientTimeMap(client);
+  }
+
+  unregiserUsbClient(id: number) {
+    const existing = this.usbClients.get(id);
+    if (!existing) {
+      defaultLogger.debug("unregiserUsbClient unknown id:" + id);
+      return;
+    }
+    defaultLogger.debug("unregiserUsbClient:" + JSON.stringify(existing.info));
+    // remove selectedClient part, connector facade will handle it
+    // unregiser client
+    this.usbClients.delete(id);
+    this.emit("client-disconnected", id);
+    this.emit("app-client-disconnected", id);
+    // remove wss.sendClientList
+    monitorUnregisterClient(existing, this.usbConnectOpt.retryTime);
+  }
+
+  emit<Event extends keyof PhysicalConnectorEvent>(
+    event: Event,
+    payload: PhysicalConnectorEvent[Event],
+  ): void {
+    this.events.emit(event, payload);
+    // remove traceRecorder part, host will handle it
+  }
+
+  registerDevice(device: BaseDevice) {
+    const { serial } = device.info;
+    const existing = this.devices.get(serial);
+    if (existing) {
+      defaultLogger.debug("registerDevice: has exists:" + device.serial);
+      return;
+    }
+    defaultLogger.debug("register new device:" + device.serial);
+    // register new device
+    this.devices.set(device.info.serial, device);
+    this.traceRecorder?.recordDeviceRegistered(device.info.serial, {
+      os: device.info.os,
+      title: device.info.title,
+    });
+    // remove auto startWatchClient, host will handle it
+    this.emit("device-connected", device);
+    setDeviceTimeMap(device);
+  }
+
+  waitDeviceUsbClients(
+    deviceId: string,
+    timeout: number = -1,
+  ): Promise<UsbClient[]> {
+    return new Promise((resolve) => {
+      if (!this.devices.has(deviceId)) {
+        resolve([]);
+      }
+      if (timeout < 0) {
+        let clients = Array.from(this.usbClients.values());
+        clients = clients.filter((client) => {
+          return client.deviceId() === deviceId;
+        });
+        resolve(Array.from(clients.values()));
+      } else {
+        const handle = (client: UsbClient) => {
+          if (client.deviceId() === deviceId) {
+            resolve([client]);
+          }
+        };
+        this.on("client-connected", handle);
+        setTimeout(() => {
+          let clients = Array.from(this.usbClients.values());
+          clients = clients.filter((client) => {
+            return client.deviceId() === deviceId;
+          });
+          this.off("client-connected", handle);
+          resolve(Array.from(clients.values()));
+        }, timeout);
+      }
+    });
+  }
+
+  // ======================================
+
+  // new helper function
+
+  async startWatchClient(
+    device: BaseDevice,
+    shouldStart: () => boolean = () => true,
+  ): Promise<void> {
+    if (!shouldStart()) {
+      return;
+    }
+    if (device instanceof AndroidDevice) {
+      await (device as AndroidDevice).forwards();
+      if (!shouldStart()) {
+        return;
+      }
+    }
+    device.startWatchClient();
+  }
+
+  closeClient(clientId: number): void {
+    const client = this.usbClients.get(clientId);
+    if (client) {
+      client.close();
+    }
+  }
+}

--- a/debug_router_connector/src/physical/index.ts
+++ b/debug_router_connector/src/physical/index.ts
@@ -1,0 +1,1 @@
+export * from "./PhysicalConnector";

--- a/debug_router_connector/src/utils/type.ts
+++ b/debug_router_connector/src/utils/type.ts
@@ -104,6 +104,20 @@ export type DebugerRouterDriverEvents = {
   "app-client-disconnected": number;
 };
 
+export type PhysicalConnectorEvent = {
+  "device-connected": BaseDevice;
+  "device-disconnected": BaseDevice;
+  "client-connected": UsbClient;
+  "client-disconnected": number;
+  // usb-app
+  "usb-client-message": {
+    id: number;
+    message: string;
+  };
+  "app-client-connected": Client;
+  "app-client-disconnected": number;
+};
+
 export type ServerErrorType = {
   code: number;
   message: string;

--- a/test/unit/physical/PhysicalConnector.test.js
+++ b/test/unit/physical/PhysicalConnector.test.js
@@ -1,0 +1,439 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("assert");
+
+const {
+  PhysicalConnector,
+} = require("../../../debug_router_connector/dist/cjs/src/physical/PhysicalConnector");
+
+const ASYNC_TEST_TIMEOUT = 250;
+
+function createConnector(option = {}) {
+  return new PhysicalConnector({
+    manualConnect: false,
+    enableAndroid: false,
+    enableIOS: false,
+    enableHarmony: false,
+    enableDesktop: false,
+    enableNetworkDevice: false,
+    traceRecorder: null,
+    ...option,
+  });
+}
+
+function collect(connector, event) {
+  const payloads = [];
+  connector.on(event, (payload) => payloads.push(payload));
+  return payloads;
+}
+
+function assertSameMembers(actual, expected) {
+  assert.strictEqual(actual.length, expected.length);
+  expected.forEach((entry) => assert(actual.includes(entry)));
+}
+
+function createDevice(
+  serial,
+  {
+    os = "Android",
+    title = `Device ${serial}`,
+    ports = [9001],
+    infoExtras = {},
+  } = {}
+) {
+  const state = {
+    startWatchCalls: 0,
+    stopWatchCalls: 0,
+    disconnectCalls: 0,
+  };
+  const info = {
+    ...infoExtras,
+    serial,
+    os,
+    title,
+  };
+
+  return {
+    info,
+    ports,
+    state,
+    get serial() {
+      return info.serial;
+    },
+    startWatchClient() {
+      state.startWatchCalls++;
+    },
+    stopWatchClient() {
+      state.stopWatchCalls++;
+    },
+    disConnect() {
+      state.disconnectCalls++;
+    },
+  };
+}
+
+function assertDeviceContract(device, expected) {
+  assert.strictEqual(typeof device.serial, "string");
+  assert.strictEqual(device.serial, expected.serial);
+  assert.strictEqual(device.info.serial, expected.serial);
+  assert.strictEqual(device.info.os, expected.os);
+  assert.strictEqual(device.info.title, expected.title);
+  assert(Array.isArray(device.ports));
+  device.ports.forEach((port) => assert(Number.isSafeInteger(port)));
+}
+
+function createClient(
+  id,
+  {
+    deviceId = "device-1",
+    port = 9000 + id,
+    app = `app-${id}`,
+    os = "Android",
+    device = "Pixel",
+    deviceModel = "Pixel",
+    sdkVersion = "1.0.0",
+    processName = `com.demo.${id}`,
+    appName = `Demo ${id}`,
+    rawInfoExtras = {},
+    queryExtras = {},
+    infoExtras = {},
+  } = {}
+) {
+  const state = {
+    closeCalls: 0,
+  };
+  const info = {
+    ...infoExtras,
+    id,
+    port,
+    query: {
+      ...queryExtras,
+      app,
+      os,
+      device,
+      device_model: deviceModel,
+      device_id: deviceId,
+      sdk_version: sdkVersion,
+      raw_info: {
+        ...rawInfoExtras,
+        AppProcessName: processName,
+        App: appName,
+      },
+    },
+  };
+
+  return {
+    info,
+    state,
+    clientId() {
+      return info.id;
+    },
+    deviceId() {
+      return info.query.device_id;
+    },
+    close() {
+      state.closeCalls++;
+    },
+  };
+}
+
+function assertClientContract(client, expected) {
+  assert(Number.isSafeInteger(client.clientId()));
+  assert.strictEqual(client.clientId(), expected.id);
+  assert.strictEqual(client.info.id, expected.id);
+  assert.strictEqual(typeof client.deviceId(), "string");
+  assert.strictEqual(client.deviceId(), expected.deviceId);
+  assert.strictEqual(client.info.query.device_id, expected.deviceId);
+  assert.strictEqual(typeof client.info.query.os, "string");
+  assert.strictEqual(typeof client.info.query.device_model, "string");
+  assert.strictEqual(typeof client.info.query.raw_info, "object");
+  assert.notStrictEqual(client.info.query.raw_info, null);
+}
+
+describe("PhysicalConnector", function () {
+  it("keeps physical options bounded and allocates unique numeric client IDs", async function () {
+    const connector = createConnector({
+      usbConnectOpt: { retryTime: 1 },
+    });
+
+    assert.strictEqual(connector.usbConnectOpt.retryTime, 3000);
+    assert.deepStrictEqual(await connector.connectDevices(-1), []);
+
+    const clientIds = [
+      connector.createClientId(),
+      connector.createClientId(),
+      connector.createClientId(),
+    ];
+    clientIds.forEach((id) => {
+      assert(Number.isSafeInteger(id));
+      assert(id > 0);
+    });
+    assert.strictEqual(new Set(clientIds).size, clientIds.length);
+  });
+
+  it("starts a device watcher only when the host predicate permits it", async function () {
+    const connector = createConnector();
+    const device = createDevice("device-1");
+    let shouldStart = false;
+
+    await connector.startWatchClient(device, () => shouldStart);
+    assert.strictEqual(device.state.startWatchCalls, 0);
+
+    shouldStart = true;
+    await connector.startWatchClient(device, () => shouldStart);
+    assert.strictEqual(device.state.startWatchCalls, 1);
+  });
+
+  it("owns device lifecycle state without automatically starting watchers", function () {
+    const trace = {
+      registered: [],
+      unregistered: [],
+      recordDeviceRegistered(serial, info) {
+        this.registered.push({ serial, info });
+      },
+      recordDeviceUnregistered(serial, info) {
+        this.unregistered.push({ serial, info });
+      },
+    };
+    const connector = createConnector({ traceRecorder: trace });
+    const connected = collect(connector, "device-connected");
+    const disconnected = collect(connector, "device-disconnected");
+    const device = createDevice("device-1", {
+      infoExtras: { transport: "USB" },
+    });
+    const duplicate = createDevice("device-1");
+
+    connector.registerDevice(device);
+    connector.registerDevice(duplicate);
+
+    assertDeviceContract(connected[0], {
+      serial: "device-1",
+      os: "Android",
+      title: "Device device-1",
+    });
+    assert.strictEqual(connected[0], device);
+    assert.strictEqual(connector.devices.get("device-1"), device);
+    assert.strictEqual(device.state.startWatchCalls, 0);
+    assert.strictEqual(duplicate.state.startWatchCalls, 0);
+    assert.deepStrictEqual(trace.registered, [
+      {
+        serial: "device-1",
+        info: { os: "Android", title: "Device device-1" },
+      },
+    ]);
+
+    connector.unregisterDevice("missing-device");
+    connector.unregisterDevice("device-1");
+
+    assert.strictEqual(connector.devices.has("device-1"), false);
+    assert.strictEqual(device.state.disconnectCalls, 1);
+    assert.deepStrictEqual(disconnected, [device]);
+    assert.deepStrictEqual(trace.unregistered, [
+      {
+        serial: "device-1",
+        info: { os: "Android", title: "Device device-1" },
+      },
+    ]);
+  });
+
+  it("owns USB client lifecycle state and emits strict physical events", function () {
+    const connector = createConnector();
+    const connected = collect(connector, "client-connected");
+    const disconnected = collect(connector, "client-disconnected");
+    const client = createClient(7, {
+      deviceId: "device-1",
+      infoExtras: { futureMetadata: true },
+      queryExtras: { futureQueryField: "kept" },
+    });
+    const duplicate = createClient(7, { deviceId: "device-2" });
+
+    connector.regiserUsbClient(client);
+    connector.regiserUsbClient(duplicate);
+
+    assertClientContract(connected[0], {
+      id: 7,
+      deviceId: "device-1",
+    });
+    assert.strictEqual(connected[0], client);
+    assert.strictEqual(connector.usbClients.get(7), client);
+    assert.strictEqual(client.info.futureMetadata, true);
+    assert.strictEqual(client.info.query.futureQueryField, "kept");
+
+    connector.unregiserUsbClient(404);
+    connector.unregiserUsbClient(7);
+
+    assert.strictEqual(connector.usbClients.has(7), false);
+    assert.deepStrictEqual(disconnected, [7]);
+    assert.strictEqual(typeof disconnected[0], "number");
+  });
+
+  it("keeps the USB message event payload typed while allowing additive fields", function () {
+    const connector = createConnector();
+    const received = [];
+    const listener = (payload) => received.push(payload);
+    const message = {
+      id: 7,
+      message: JSON.stringify({ method: "Runtime.consoleAPICalled" }),
+      futureMetadata: "kept",
+    };
+
+    connector.on("usb-client-message", listener);
+    connector.emit("usb-client-message", message);
+    connector.off("usb-client-message", listener);
+    connector.emit("usb-client-message", {
+      id: 8,
+      message: "ignored after unsubscribe",
+    });
+
+    assert.deepStrictEqual(received, [message]);
+    assert(Number.isSafeInteger(received[0].id));
+    assert(received[0].id > 0);
+    assert.strictEqual(typeof received[0].message, "string");
+    assert.strictEqual(received[0].futureMetadata, "kept");
+  });
+
+  it("queries current and future devices by stable serial identity", async function () {
+    const connector = createConnector();
+    const deviceA = createDevice("device-a");
+    const deviceB = createDevice("device-b");
+    connector.registerDevice(deviceA);
+
+    assertSameMembers(await connector.getDevices(-1, null), [deviceA]);
+    assert.deepStrictEqual(await connector.getDevices(-1, "device-a"), [
+      deviceA,
+    ]);
+    assert.deepStrictEqual(await connector.getDevices(-1, "missing"), []);
+
+    const waiting = connector.getDevices(ASYNC_TEST_TIMEOUT, "device-b");
+    setImmediate(() => connector.registerDevice(deviceB));
+    assert.deepStrictEqual(await waiting, [deviceB]);
+
+    assert.deepStrictEqual(await connector.getDevices(0, "never"), []);
+  });
+
+  it("filters USB clients by device identity and platform application name", async function () {
+    const connector = createConnector();
+    const device = createDevice("device-1");
+    const android = createClient(1, {
+      deviceId: "device-1",
+      os: "Android",
+      processName: "com.target",
+      rawInfoExtras: { futureAndroidField: "kept" },
+    });
+    const ios = createClient(2, {
+      deviceId: "device-1",
+      os: "iOS",
+      deviceModel: "iPhone 15",
+      appName: "TargetApp",
+    });
+    const otherDevice = createClient(3, {
+      deviceId: "device-2",
+      processName: "com.target",
+    });
+    connector.registerDevice(device);
+    connector.regiserUsbClient(android);
+    connector.regiserUsbClient(ios);
+    connector.regiserUsbClient(otherDevice);
+
+    assertSameMembers(connector.getAllUsbClients(), [
+      android,
+      ios,
+      otherDevice,
+    ]);
+    assert.deepStrictEqual(
+      await connector.getDeviceUsbClients("device-1", -1, "com.target"),
+      [android]
+    );
+    assert.deepStrictEqual(
+      await connector.getDeviceUsbClients("device-1", -1, "TargetApp"),
+      [ios]
+    );
+    assert.deepStrictEqual(
+      await connector.getDeviceUsbClients("device-1", -1, "missing-app"),
+      []
+    );
+  });
+
+  it("waits for the first USB client belonging to the requested device", async function () {
+    const connector = createConnector();
+    connector.registerDevice(createDevice("device-1"));
+    connector.registerDevice(createDevice("device-2"));
+    const ignored = createClient(1, { deviceId: "device-2" });
+    const matching = createClient(2, { deviceId: "device-1" });
+
+    const waiting = connector.waitDeviceUsbClients(
+      "device-1",
+      ASYNC_TEST_TIMEOUT
+    );
+    setImmediate(() => {
+      connector.regiserUsbClient(ignored);
+      connector.regiserUsbClient(matching);
+    });
+
+    assert.deepStrictEqual(await waiting, [matching]);
+    assert.deepStrictEqual(
+      await connector.waitDeviceUsbClients("unknown-device", 0),
+      []
+    );
+  });
+
+  it("waits for a named USB client without accepting another device", async function () {
+    const connector = createConnector();
+    connector.registerDevice(createDevice("device-1"));
+    connector.registerDevice(createDevice("device-2"));
+    const ignored = createClient(1, {
+      deviceId: "device-2",
+      processName: "com.target",
+    });
+    const matching = createClient(2, {
+      deviceId: "device-1",
+      processName: "com.target",
+    });
+
+    const waiting = connector.getDeviceUsbClients(
+      "device-1",
+      ASYNC_TEST_TIMEOUT,
+      "com.target"
+    );
+    setImmediate(() => {
+      connector.regiserUsbClient(ignored);
+      connector.regiserUsbClient(matching);
+    });
+
+    assert.deepStrictEqual(await waiting, [matching]);
+  });
+
+  it("closes only the USB client selected by its numeric ID", function () {
+    const connector = createConnector();
+    const client = createClient(5);
+    connector.regiserUsbClient(client);
+
+    connector.closeClient(404);
+    assert.strictEqual(client.state.closeCalls, 0);
+
+    connector.closeClient(5);
+    assert.strictEqual(client.state.closeCalls, 1);
+  });
+
+  it("stops all physical resources and makes connector close idempotent", async function () {
+    const connector = createConnector();
+    const deviceA = createDevice("device-a");
+    const deviceB = createDevice("device-b");
+    const clientA = createClient(1, { deviceId: "device-a" });
+    const clientB = createClient(2, { deviceId: "device-b" });
+    connector.registerDevice(deviceA);
+    connector.registerDevice(deviceB);
+    connector.regiserUsbClient(clientA);
+    connector.regiserUsbClient(clientB);
+
+    await connector.close();
+    await connector.close();
+
+    assert.strictEqual(deviceA.state.stopWatchCalls, 1);
+    assert.strictEqual(deviceB.state.stopWatchCalls, 1);
+    assert.strictEqual(clientA.state.closeCalls, 1);
+    assert.strictEqual(clientB.state.closeCalls, 1);
+  });
+});


### PR DESCRIPTION
[Feature] Extract physical connector layer
Summary of change:
Extract physical device discovery, USB client management, and lifecycle
handling from DebugRouterConnector into a standalone PhysicalConnector.

Add device/client monitoring helpers, physical-layer events and exports,
and focused unit coverage while retaining legacy DeviceManager compatibility.