### PR TITLE
[Optimize][Connector] Add runtime network device watching

### DIFF
--- a/debug_router_connector/README.md
+++ b/debug_router_connector/README.md
@@ -42,6 +42,24 @@ const connector = new DebugRouterConnector({
 });
 ```
 
+#### Add a Network Device at Runtime
+
+Network devices can be added after initialization:
+
+```js
+await connector.watchNetworkDeviceAtIp({
+  ip: "192.168.1.20",
+  port: [8901, 8902],
+});
+
+await connector.watchNetworkDeviceAtIp({
+  ip: "192.168.1.21",
+  port: [8901, 8902],
+});
+```
+
+Each IP is watched once. Repeated calls with the same IP do nothing.
+
 #### Connection trace (optional)
 Use `connectionTrace` to enable flat JSON-line connection logging, or set `DriverConnectionTracePath` to a file path. Each record includes a monotonically increasing `sequence`; socket-backed records also include `connectionAttemptId` for later trace analysis.
 

--- a/debug_router_connector/src/connector/DebugRouterConnector.ts
+++ b/debug_router_connector/src/connector/DebugRouterConnector.ts
@@ -102,6 +102,10 @@ export class DebugRouterConnector {
         port: number[];
       }
     | undefined;
+  private readonly networkDeviceManagers = new Map<
+    string,
+    NetworkDeviceManager
+  >();
   readonly adbOption: any;
   readonly hdcOption: any;
   readonly usbConnectOpt: {
@@ -192,9 +196,15 @@ export class DebugRouterConnector {
     if (this.enableNetworkDevice && this.networkDeviceOpt) {
       if (this.networkDeviceOpt) {
         // NetWorkDevices use ip as their serial.
-        this.devicesManager.add(
-          new NetworkDeviceManager(this, this.networkDeviceOpt),
+        const networkDeviceManager = new NetworkDeviceManager(
+          this,
+          this.networkDeviceOpt,
         );
+        this.networkDeviceManagers.set(
+          this.networkDeviceOpt.ip,
+          networkDeviceManager,
+        );
+        this.devicesManager.add(networkDeviceManager);
       } else {
         getDriverReportService()?.report("network_connect_error", null, {
           msg: "networkDeviceOpt == undefined",
@@ -430,6 +440,25 @@ export class DebugRouterConnector {
 
   addDeviceManager(manager: DeviceManager) {
     this.devicesManager.add(manager);
+  }
+
+  async watchNetworkDeviceAtIp(options: {
+    ip: string;
+    port: number[];
+  }): Promise<void> {
+    if (this.networkDeviceManagers.has(options.ip)) {
+      return;
+    }
+    const networkDeviceManager = new NetworkDeviceManager(this, options);
+    this.networkDeviceManagers.set(options.ip, networkDeviceManager);
+    this.devicesManager.add(networkDeviceManager);
+    await networkDeviceManager.watchDevices().catch((e) => {
+      getDriverReportService()?.report("device_connect_error", null, {
+        msg: "watchDevices error:" + e?.message,
+        stage: "device",
+      });
+      throw e;
+    });
   }
 
   private async startDeviceListeners() {

--- a/test/e2e_test/connector_test/debug_router_connector_auto_test.js
+++ b/test/e2e_test/connector_test/debug_router_connector_auto_test.js
@@ -466,6 +466,67 @@ async function runFakeNetworkCheck() {
   }
 }
 
+async function runDynamicNetworkCheck(manualConnect) {
+  logStep(
+    `checking runtime NetworkDevice add with manualConnect=${manualConnect}`,
+  );
+  const firstApp = await startFakeDebugRouterAppServer();
+  const driver = new DebugRouterConnector({
+    manualConnect,
+    enableWebSocket: false,
+    enableAndroid: false,
+    enableIOS: false,
+    enableHarmony: false,
+    enableDesktop: false,
+    enableNetworkDevice: false,
+  });
+  const connectedDevices = [];
+  driver.on("device-connected", (device) =>
+    connectedDevices.push(device.serial),
+  );
+
+  const connectClient = async (ip, expectedApp) => {
+    if (manualConnect) {
+      const clients = await driver.connectUsbClients(ip, 4000, false);
+      assert.strictEqual(clients.length, 1);
+    } else {
+      await waitFor(
+        () => driver.getAllUsbClients().length === 1,
+        4000,
+        `automatic client connection for ${ip}`,
+      );
+    }
+    assert.strictEqual(
+      driver.getAllUsbClients()[0].info.query.app,
+      expectedApp,
+    );
+  };
+
+  try {
+    await driver.watchNetworkDeviceAtIp({
+      ip: "127.0.0.1",
+      port: [firstApp.port],
+    });
+    await driver.watchNetworkDeviceAtIp({
+      ip: "127.0.0.2",
+      port: [firstApp.port],
+    });
+    await driver.watchNetworkDeviceAtIp({
+      ip: "127.0.0.1",
+      port: [firstApp.port],
+    });
+    assert.deepStrictEqual(connectedDevices, ["127.0.0.1", "127.0.0.2"]);
+    assert.deepStrictEqual(Array.from(driver.devices.keys()), [
+      "127.0.0.1",
+      "127.0.0.2",
+    ]);
+    await connectClient("127.0.0.1", firstApp.appName);
+  } finally {
+    await driver.close();
+    await firstApp.close();
+  }
+}
+
 function platformOptions(platform) {
   return {
     enableAndroid: platform === "android" || platform === "all",
@@ -609,6 +670,8 @@ async function main() {
   if (args.mode === "no-device") {
     await runEmptyDiscoveryCheck();
     await runFakeNetworkCheck();
+    await runDynamicNetworkCheck(true);
+    await runDynamicNetworkCheck(false);
   } else {
     await runRealDeviceScenario(args);
   }


### PR DESCRIPTION
## Summary

- add `watchNetworkDeviceAtIp` for watching NetworkDevice IPs after connector initialization
- support multiple NetworkDevices by keeping one manager per IP
- treat repeated calls for the same IP as no-ops
- preserve constructor-based NetworkDevice initialization
- document the runtime API and cover manual/automatic connection modes

## Test Plan

- `npm run build` in `debug_router_connector`
- `npm test` in `test/e2e_test/connector_test`