### PR TITLE
[Feature] Add multiplexer control transport

### DIFF
--- a/agents/DebugRouter Multiplexer Technical Design.md
+++ b/agents/DebugRouter Multiplexer Technical Design.md
@@ -26,9 +26,9 @@ The most important implementation boundary is: the public `DebugRouterConnector`
 | debug_router SDK            | The SDK-side DebugRouter component. It receives debugging messages from frontends and returns SDK runtime events and responses.                                                                                                                |
 | debug_router_connector      | The PC-side DebugRouter connection library. It discovers devices, connects to SDK runtimes, and provides a WebSocket debugging entry for Lynx DevTool/browser DevTool pages.                                                                   |
 | DebugRouter Multiplexer     | A local multiplexing mechanism inside the connector. A daemon owns the real device and SDK connections, isolates messages, rewrites IDs, and routes responses for multiple frontends.                                                          |
-| Multiplexer daemon          | A local detached shared process. It owns real physical connections, the control server, the WebSocket server, snapshot/event broadcast, and routing.                                                                                           |
+| Multiplexer daemon          | A local detached shared process composed of the process entry and `MultiplexerDaemonHost`. It is a deployment role rather than a standalone lifecycle class.                                                                                   |
 | memoized notification query | An ID-less `Customized` query whose runtime reply is an SDK-initiated notification. The daemon can coalesce duplicate queries and briefly reuse the latest notification for the same runtime client.                                           |
-| control client              | A daemon client created when a normal connector process connects to the daemon through the control WebSocket.                                                                                                                                  |
+| control client              | A daemon client created after a normal connector process registers over the local `node:net` control endpoint.                                                                                                                                 |
 | WebSocket Driver frontend   | A WebSocket frontend page whose type is `Driver`.                                                                                                                                                                                              |
 | runtime client              | A debugging target for an SDK runtime, including USB runtime clients and WiFi runtimes connected as WebSocket app clients. The daemon tracks both types and synchronizes WiFi runtime mirrors to facades that requested the WebSocket service. |
 
@@ -99,8 +99,7 @@ Connector-side daemon client and mirror objects:
 Daemon side:
 
 - `debug_router_connector/src/multiplexer/daemon/entry.ts`
-- `debug_router_connector/src/multiplexer/daemon/MultiplexerDaemon.ts`
-- `debug_router_connector/src/multiplexer/daemon/MultiplexerHost.ts`
+- `debug_router_connector/src/multiplexer/daemon/MultiplexerDaemonHost.ts`
 - `debug_router_connector/src/multiplexer/daemon/MemoizedNotificationQueryTable.ts`
 - `debug_router_connector/src/multiplexer/daemon/MultiplexerControlServer.ts`
 - `debug_router_connector/src/multiplexer/daemon/MultiplexerControlConnection.ts`
@@ -111,14 +110,13 @@ Protocol and utilities:
 
 - `debug_router_connector/src/multiplexer/protocol/control.ts`
 - `debug_router_connector/src/multiplexer/protocol/debuginfo.ts`
-- `debug_router_connector/src/multiplexer/protocol/discovery.ts`
 - `debug_router_connector/src/multiplexer/protocol/event.ts`
 - `debug_router_connector/src/multiplexer/protocol/index.ts`
 - `debug_router_connector/src/multiplexer/protocol/snapshot.ts`
 - `debug_router_connector/src/multiplexer/protocol/validation.ts`
+- `debug_router_connector/src/multiplexer/transport/MultiplexerControlTransport.ts`
 - `debug_router_connector/src/multiplexer/utils/paths.ts`
 - `debug_router_connector/src/multiplexer/utils/FileLock.ts`
-- `debug_router_connector/src/multiplexer/utils/atomic_file.ts`
 
 WebSocket and physical layer:
 
@@ -135,21 +133,20 @@ The current `src/connector` directory only exports the new `DebugRouterConnector
 ```text
 Caller process
   DebugRouterConnector
-    MultiplexerDaemonClient
-      ws://127.0.0.1:<controlPort>/debug-router-multiplexer/control
-        Multiplexer daemon
-          MultiplexerHost
-            PhysicalConnector
-              SDK runtime / device
+    MultiplexerDaemonManager ── starts / replaces ──────> daemon/entry.ts
+    MultiplexerDaemonClient  ── fixed endpoint ─────────> MultiplexerControlServer
 
-WebSocket frontends
-  ws://<host>:<wssPort>/mdevices/page/android
-    daemon-side WebSocketController
-      MultiplexerHost
-        USB SDK runtime / WiFi SDK runtime / device
+Multiplexer daemon process
+  daemon/entry.ts
+    MultiplexerDaemonHost
+      MultiplexerControlServer
+      PhysicalConnector ── USB ── SDK runtime / device
+      WebSocketController ── WiFi / Driver frontend
 ```
 
-Connector processes no longer directly own real device watchers or SDK runtime/WebSocket connections. USB physical connections exist only in daemon-side `MultiplexerHost -> PhysicalConnector`, while daemon-side `WebSocketController` owns WiFi runtime and Driver frontend connections. Connector processes maintain local `MultiplexerDevice`, `MultiplexerUsbClient`, and `MultiplexerWebSocketClient` mirrors; WebSocket mirrors and events are exposed only to control clients that called `startWSServer()`.
+The Multiplexer daemon is a process boundary, not an additional object layer. `entry.ts` adapts process startup and termination to one `MultiplexerDaemonHost`; Host composes and owns the control, physical, WebSocket, routing, and compatibility resources used by that process.
+
+Connector processes no longer directly own real device watchers or SDK runtime/WebSocket connections. USB physical connections exist only in daemon-side `MultiplexerDaemonHost -> PhysicalConnector`, while daemon-side `WebSocketController` owns WiFi runtime and Driver frontend connections. Connector processes maintain local `MultiplexerDevice`, `MultiplexerUsbClient`, and `MultiplexerWebSocketClient` mirrors; WebSocket mirrors and events are exposed only to control clients that called `startWSServer()`.
 
 ### 4.2 Local State Directory
 
@@ -157,44 +154,24 @@ Default directory:
 
 ```text
 ~/.DebugRouterConnector/multiplexer/
-  spawn.lock
-  daemon.lock
-  daemon.json
+  control.sock       # Unix-like only; Windows uses a named pipe
+  spawn.lock/
+    owner.json
 ```
 
 `multiplexerRootDir` or `multiplexerDataDir` can override the path, mainly for tests, isolated runs, or special packaging scenarios.
 
-`daemon.json` is defined by `MultiplexerDiscoveryInfo`:
+The control endpoint is derived directly from the data directory. Unix-like platforms use `<dataDir>/control.sock`; Windows uses `\\.\pipe\<dataDir>` without hashing or path normalization. Custom Windows data directories are a debug/embedding responsibility and must already be valid for the intended named-pipe environment.
 
-```ts
-type MultiplexerDebugInfo = {
-  protocolVersion?: number;
-  clientVersion?: string;
-  daemonVersion?: string;
-  processId?: number;
-  timestamp?: number;
-};
-
-type MultiplexerDiscoveryInfo = {
-  pid: number;
-  protocolVersion: number;
-  minSupportedProtocolVersion?: number;
-  controlPort: number;
-  heartbeat: number;
-  startedAt?: number;
-  debugInfo?: MultiplexerDebugInfo;
-};
-```
-
-`spawn.lock` serializes daemon startup and is only held during the connector's daemon ensure window. `daemon.lock` is held by the daemon process and marks the current daemon owner. `daemon.json` is written after the daemon starts the control server and is refreshed on each heartbeat. Writes use `writeJsonAtomic()` so other processes do not read partial JSON.
+`spawn.lock` serializes daemon replacement, cleanup, and startup and is held only during the manager's ensure window. The daemon does not hold a runtime lock. Instead, Manager gives every spawned daemon an `argv0` marker derived from `dataDir`, then locates stale daemon pids through `find-process` when cleanup is required. Process identity is not part of normal health or control messages. There is no discovery file, heartbeat file, control port, daemon lock, or instance token.
 
 ## 5. Public `DebugRouterConnector` Facade
 
 The `DebugRouterConnector` constructor creates:
 
-1. `MultiplexerDiscovery`, which reads and validates `daemon.json`.
+1. `MultiplexerDiscovery`, which probes the fixed endpoint and classifies health/protocol compatibility.
 2. `MultiplexerDaemonManager`, which handles ensure, spawn, replacement, health checks, and stale cleanup.
-3. `MultiplexerDaemonClient`, which connects to the daemon control WebSocket, sends RPCs, and receives events.
+3. `MultiplexerDaemonClient`, which registers over the local control socket, sends RPCs, and receives events.
 4. Local `DriverClient` and device, USB runtime, WiFi runtime, and WebSocket frontend mirror Maps. Connection trace is not created or owned by the facade.
 
 If `manualConnect` is false, the constructor automatically calls `connectDevices()`. The Host reacquires the legacy `LatestDriverProcess` ownership inside `connectDevices()` and `startAllDeviceClientWatchers()`, so desired-state recovery restores ownership and physical watchers with one control RPC.
@@ -209,73 +186,67 @@ Current public facade behavior:
 - `getAllWebsocketAppClients()` and `getAllAppClients()` continue to expose WiFi runtimes through `MultiplexerWebSocketClient` proxies. Proxy send and close operations become daemon RPCs.
 - `sendMessageToWeb()` and `sendMessageToApp()` keep the original public call shape, but both forward through the daemon's unified `sendMessageWithoutReply` RPC.
 - `disableAllClients()` and `addDeviceManager()` no longer operate on physical objects in the Multiplexer-only facade; they only log warnings.
-- `close()` only closes the current connector's control socket, removes subscriptions, and clears local mirrors. It does not directly close the daemon. Daemon shutdown is controlled by idle timeout or shutdown/replacement flow.
+- In the normal path, `close()` only closes the current Connector's control socket, removes subscriptions, and clears its WebSocket-server mirror. It does not directly close the shared daemon; daemon shutdown is controlled by idle timeout or shutdown/replacement flow. `forceRespawnDaemon` is a debug/test-only exception: closing such a Connector force-stops the current daemon and cleans its artifacts.
 
 When the daemon control socket disconnects, the facade clears local mirrors, rejects pending RPCs, and schedules desired-state recovery after 100 ms: reconnect the daemon, restore device discovery, restore `startAllDeviceClientWatchers()`, and restore a previously requested WebSocket server.
 
 ## 6. Daemon Discovery, Startup, and Replacement
 
-When `DebugRouterConnector` forwards some behavior to the daemon, it calls `MultiplexerDaemonClient.call()`. `MultiplexerDaemonClient.call()` validates the complete RPC request before connecting; `connect()` then obtains an available daemon through `MultiplexerDaemonManager.ensureDaemon()`.
+When `DebugRouterConnector` forwards some behavior to the daemon, it calls `MultiplexerDaemonClient.call()`. This method validates the method-specific RPC parameters and ensures an available daemon by default. Daemon replacement passes `ensureDaemon: false` to send the shutdown RPC without starting another daemon, while `sendRpc()` is the private send path after registration.
 
-`MultiplexerDiscovery.validateDiscovery()` validates in this order:
+`MultiplexerDaemonClient.connect()` owns connection idempotency through its in-flight `connecting` Promise. Manager does not keep a second `ensureDaemon()` Promise; one production facade constructs one DaemonClient and one Manager, while different facades coordinate daemon startup through `spawn.lock`.
 
-1. Missing `daemon.json`, invalid JSON, or invalid shape returns unusable.
-2. Missing `protocolVersion` returns unusable.
-3. Heartbeat older than `multiplexerStaleTimeout` returns stale.
-4. Connector protocol lower than daemon `minSupportedProtocolVersion` returns `connector-protocol-too-old`.
-5. Daemon protocol lower than connector protocol returns `replace-required`.
-6. Other compatible cases return usable.
+`MultiplexerDiscovery.probeHealth()` opens the fixed endpoint, sends a framed `{ kind: "health" }` first message, validates the framed `health-response`, and compares protocol versions. A normal health response contains `kind`, `ok`, `protocolVersion`, and `isInUse`; optional `debugInfo` remains diagnostic and is not used for cleanup or feature detection. `isInUse` follows the daemon idle-consumer definition: it is true when at least one registered Connector control client or Driver WebSocket frontend is connected. The temporary Health socket and WiFi runtime/app connections do not count.
 
 Current default protocol constants:
 
 ```text
 MULTIPLEXER_PROTOCOL_VERSION = 1
-MULTIPLEXER_MIN_SUPPORTED_PROTOCOL_VERSION = 1
 ```
 
 `MultiplexerDaemonManager` handles validation results as follows:
 
-- usable: first call `http://127.0.0.1:<controlPort>/health`; reuse only when health is OK.
-- usable but health temporarily fails: if the pid is still alive, retry 3 times with `readyPollInterval`.
-- `replace-required`: acquire `spawn.lock`, first request graceful daemon shutdown through the `shutdownDaemon` RPC; if the daemon does not exit, try SIGTERM/SIGKILL; then clean up `daemon.lock` and `daemon.json` and start a new daemon.
-- connector protocol too old: throw an upgrade error. Do not clean up or kill the newer daemon.
-- stale, invalid, or missing: acquire `spawn.lock` and run cleanup. If the discovery pid is alive, stop it. If the `daemon.lock` owner is alive and is not the pid just stopped, stop by lock owner. Finally clean local artifacts and spawn.
+- `usable`: reuse immediately.
+- `replace-required`: the daemon protocol is older and `isInUse` is false. Acquire `spawn.lock`, locate the marked daemon process, and request graceful shutdown through `shutdownDaemon`; if that same process does not exit, try SIGTERM/SIGKILL; then clean the stale Unix socket and start a new daemon.
+- `daemon-upgrade-blocked-by-active-connections`: the daemon protocol is older but `isInUse` is true. Throw an error without acquiring `spawn.lock`, stopping the daemon, or replacing it.
+- `unreachable`, `timeout`, `invalid-frame`, or `invalid-response`: acquire `spawn.lock`, locate the first process carrying the current data directory's daemon marker, stop it when still alive, clean the Unix socket, and spawn.
+
+The initial health check is followed by up to three delayed retries for all four transient/unusable health outcomes. `usable`, `replace-required`, and `daemon-upgrade-blocked-by-active-connections` return immediately. In the normal ensure path, once `spawn.lock` is acquired, the manager does not probe again; the window after the initial probe is deliberately kept simple.
+
+If the current Manager acquires `spawn.lock`, it owns the cleanup and spawn attempt. A subsequent `waitUntilReady()` failure therefore means the daemon it spawned did not become reusable, so the detailed error, including the last validation and last health error, is propagated to the caller.
+
+If another Connector owns `spawn.lock`, the current Manager immediately returns to the outer `ensureDaemon()` loop without calling `waitUntilReady()`. The next `probeDaemonHealthWithRetry()` observes the other Manager's startup and already provides a short bounded retry window before another lock attempt. This keeps readiness polling in one place. An active older daemon remains a terminal result and is reported without replacement.
 
 Important defaults:
 
 ```text
 startupTimeout = 5000ms
-readyPollInterval = 100ms
+readyPollInterval = 50ms
 replacementTimeout = 1000ms
 healthCheckTimeout = 500ms
 spawnLockStaleTimeout = startupTimeout + replacementTimeout + 1000ms
 ```
 
-Spawn uses the current Node executable to start `multiplexer/daemon/entry.js` as a detached child with `stdio: "ignore"`, then calls `unref()`. Startup arguments include discovery/lock paths, protocol versions, control port, heartbeat, legacy driver dir, idle timeout, WebSocket config, and daemon-side `PhysicalConnectorOption`. Serialized `debugInfo` is included only when diagnostic context was explicitly configured.
+Manager starts `multiplexer/daemon/entry.js` as a detached child process. A process marker derived from the Multiplexer data directory lets Manager identify the daemon during replacement or stale cleanup, but it is not part of the daemon's runtime protocol or Host configuration. Entry receives only the configuration required to construct Host, such as the control endpoint, protocol version, physical connection options, WebSocket settings, trace settings, and idle policy.
 
 ## 7. Daemon Process and Host
 
-`entry.ts` parses daemon arguments, creates `MultiplexerHost` and `MultiplexerDaemon`, and registers cleanup logic for `beforeExit`, `SIGINT`, `SIGTERM`, `uncaughtException`, and `unhandledRejection`. Cleanup calls `daemon.stop()`. Forced exit paths wait at most 3000 ms.
+`entry.ts` is the adapter between process lifecycle and the daemon runtime. It parses Manager-provided configuration, installs daemon-local dependencies, constructs one `MultiplexerDaemonHost`, starts it, and coordinates process termination when Host or the operating environment requests shutdown.
 
-`MultiplexerDaemon.start()` flow:
+The responsibility boundary is:
 
-1. Acquire `daemon.lock`.
-2. Start `MultiplexerHost`.
-3. Read the actual Host control port.
-4. Write `daemon.json`.
-5. Start the heartbeat timer, which refreshes discovery heartbeat every 1000 ms by default.
+1. `MultiplexerDaemonManager` decides whether a daemon must be reused, started, replaced, or force-stopped.
+2. `entry.ts` owns process construction and termination, and translates process-level configuration into one Host configuration.
+3. `MultiplexerDaemonHost` owns startup, shutdown, and all runtime resources inside the daemon process.
 
-`MultiplexerDaemon.stop()` flow:
+There is no separate `MultiplexerDaemon` lifecycle wrapper. Host options are provided once at construction, and `host.start()` only activates the resources represented by that configuration. Host-requested idle or explicit shutdown is routed back to entry, which stops Host before ending the process.
 
-1. Stop the heartbeat timer.
-2. Stop Host.
-3. Delete `daemon.json`.
-4. Release `daemon.lock`.
+Host composes its control server and WebSocket controller through small structural contracts. These contracts keep the subcomponents independently testable without making the core Host inherit from or explicitly implement server-side wrapper interfaces.
 
-`MultiplexerHost` is the core daemon object. It is responsible for:
+`MultiplexerDaemonHost` is the core daemon object. It is responsible for:
 
 - Owning the real `PhysicalConnector`.
-- Starting the control server that serves `/health` and `/debug-router-multiplexer/control`.
+- Starting the fixed local control server and handling health/register first-message handshakes.
 - Starting the WebSocket server that continues to use `/mdevices/page/android`.
 - Managing device watchers, runtime client watchers, and WebSocket clients.
 - Serializing snapshots and broadcasting control events.
@@ -286,7 +257,20 @@ Spawn uses the current Node executable to start `multiplexer/daemon/entry.js` as
 
 ## 8. Control Protocol
 
-### 8.1 RPC
+### 8.1 Transport and First-message Handshake
+
+The internal control plane uses Node.js `node:net`. Because a socket is a byte stream rather than a message transport, every JSON message is framed as the four ASCII bytes `$MUX`, a four-byte unsigned big-endian payload length, and that many UTF-8 JSON bytes. The transport uses `bufferpack` to encode and decode the header. While reading, it advances through interference bytes until it finds `$MUX`, then parses the length and payload; a header split across socket chunks remains buffered for the next read. The default maximum payload is 16 MiB and the maximum accumulated receive buffer is 32 MiB. Zero-length payloads, oversized frames/buffers, invalid JSON, and EOF with an incomplete frame close the transport with a diagnostic error.
+
+`MultiplexerControlTransport.send()` writes one complete frame with `socket.write()`. It intentionally does not add an application-level write queue or a separate pause/resume backpressure state machine; ordering and system buffering are provided by `net.Socket`, while the control protocol enforces bounded frame and receive-buffer sizes.
+
+The first framed message on a newly accepted socket must be one of:
+
+- `health`: daemon replies with `health-response` and closes the short-lived probe connection.
+- `register`: daemon replies with `register-response`, allocates a `controlId`, and promotes the socket to a long-lived RPC/event connection.
+
+Any other first message receives `handshake-error-response`. After registration, only valid `ControlRpcRequest` messages are accepted. Socket `end` records an incomplete-frame error when needed and destroys the socket; upper layers receive their single close notification from the later socket `close` event.
+
+### 8.2 RPC
 
 Every request explicitly contains `kind`, `id`, `method`, and `params`. Even an RPC with no business parameters sends `params: {}`:
 
@@ -326,20 +310,20 @@ type ControlRpcResponse<M extends ControlRpcMethod> =
 
 The current method contracts are:
 
-| RPC                            | Parameters                                             | Successful result     | Purpose                                                                       |
-| ------------------------------ | ------------------------------------------------------ | --------------------- | ----------------------------------------------------------------------------- |
-| `connectDevices`               | `{ timeout?, serial?, isAutoListenClients? }`          | `DeviceSnapshot[]`    | Start physical discovery and return the current matching devices.             |
-| `connectUsbClients`            | `{ deviceId, timeout?, waitTimeout?, clientName? }`    | `ClientSnapshot[]`    | Start one device's runtime watcher and return the current matching runtimes.   |
-| `startDeviceClientWatcher`     | `{ deviceId }`                                         | `{}`                  | Start one device's runtime watcher without returning a snapshot.               |
-| `stopDeviceClientWatcher`      | `{ deviceId }`                                         | `{}`                  | Stop one device's runtime watcher without disconnecting the device.            |
-| `disconnectDevice`             | `{ deviceId }`                                         | `{}`                  | Disconnect one physical device.                                               |
-| `shutdownDaemon`               | `{ reason? }`                                          | `{}`                  | Request graceful daemon shutdown for replacement or explicit shutdown.         |
-| `startWSServer`                | `{}`                                                   | `WebSocketServerInfo` | Start or reuse the WebSocket server and return `{ port, host, roomId? }`.       |
-| `startAllDeviceClientWatchers` | `{}`                                                   | `{}`                  | Watch all current devices and automatically watch later devices.               |
-| `stopAllDeviceClientWatchers`  | `{}`                                                   | `{}`                  | Stop all watchers and disable automatic watching for later devices.            |
-| `sendMessageWithReply`         | `{ clientId, message: RequireMessageType }`            | `ResponseMessageType` | Send a request-response message to one USB or WiFi runtime.                    |
-| `sendMessageWithoutReply`      | `{ target: "app" \| "web", clientId, message }`        | `{}`                  | Send a fire-and-forget message to an App runtime or WebSocket Driver.           |
-| `closeClient`                  | `{ clientId }`                                         | `{}`                  | Close one USB or WiFi runtime client.                                           |
+| RPC                            | Parameters                                          | Successful result     | Purpose                                                                      |
+| ------------------------------ | --------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------- |
+| `connectDevices`               | `{ timeout?, serial?, isAutoListenClients? }`       | `DeviceSnapshot[]`    | Start physical discovery and return the current matching devices.            |
+| `connectUsbClients`            | `{ deviceId, timeout?, waitTimeout?, clientName? }` | `ClientSnapshot[]`    | Start one device's runtime watcher and return the current matching runtimes. |
+| `startDeviceClientWatcher`     | `{ deviceId }`                                      | `{}`                  | Start one device's runtime watcher without returning a snapshot.             |
+| `stopDeviceClientWatcher`      | `{ deviceId }`                                      | `{}`                  | Stop one device's runtime watcher without disconnecting the device.          |
+| `disconnectDevice`             | `{ deviceId }`                                      | `{}`                  | Disconnect one physical device.                                              |
+| `shutdownDaemon`               | `{ reason? }`                                       | `{}`                  | Request graceful daemon shutdown for replacement or explicit shutdown.       |
+| `startWSServer`                | `{}`                                                | `WebSocketServerInfo` | Start or reuse the WebSocket server and return `{ port, host, roomId? }`.    |
+| `startAllDeviceClientWatchers` | `{}`                                                | `{}`                  | Watch all current devices and automatically watch later devices.             |
+| `stopAllDeviceClientWatchers`  | `{}`                                                | `{}`                  | Stop all watchers and disable automatic watching for later devices.          |
+| `sendMessageWithReply`         | `{ clientId, message: RequireMessageType }`         | `ResponseMessageType` | Send a request-response message to one USB or WiFi runtime.                  |
+| `sendMessageWithoutReply`      | `{ target: "app" \| "web", clientId, message }`     | `{}`                  | Send a fire-and-forget message to an App runtime or WebSocket Driver.        |
+| `closeClient`                  | `{ clientId }`                                      | `{}`                  | Close one USB or WiFi runtime client.                                        |
 
 Single-device watching uses separate `startDeviceClientWatcher({ deviceId })` and `stopDeviceClientWatcher({ deviceId })` RPCs; `deviceId` must be non-empty and extra fields are rejected at runtime. All-device watching uses `startAllDeviceClientWatchers({})` and `stopAllDeviceClientWatchers({})`; the wire protocol has no `force` field. The public `DebugRouterConnector.startWatchAllClients(_force)` parameter remains only for source compatibility and is intentionally not forwarded. Stopping all watchers also disables `connectDevices()` auto-watch behavior for devices discovered later; either start RPC can enable watching again. `connectUsbClients` remains separate because it returns `ClientSnapshot[]`, while watcher RPCs return `result: {}`.
 
@@ -353,7 +337,7 @@ Single-device watching uses separate `startDeviceClientWatcher({ deviceId })` an
 
 The default RPC timeout is 5000 ms. RPCs with a positive operation `timeout` use `max(rpcTimeout, timeout + 1000ms)`; RPCs without an operation timeout continue to use the default timeout, with no method-specific exception.
 
-### 8.2 Event
+### 8.3 Event
 
 `ControlEvent` currently defines:
 
@@ -402,7 +386,7 @@ Runtime routing is transport-independent: USB and WiFi share ID restoration, rou
 
 `DebugRouterConnector.applyHostEvent()` synchronizes snapshots into local mirrors and maps unified `client-message` sources back to compatibility event names such as `usb-client-message`, `ws-client-message`, and `ws-web-message`. The public Connector event surface therefore remains unchanged.
 
-### 8.3 Snapshot
+### 8.4 Snapshot
 
 `snapshot` is the daemon's authoritative full state at one point in time, not an incremental change list:
 
@@ -441,9 +425,9 @@ type WebSocketClientSnapshot = {
 
 The full-state model handles initial connection, late WebSocket requesters, reconnect, missed-event correction, and lifecycle ordering with one representation. Connector mirrors calculate additions and removals by comparing the new snapshot with their current Maps; no device/client connected or disconnected event is sent over the control protocol.
 
-### 8.4 Diagnostic Context and Version Arbitration
+### 8.5 Diagnostic Context and Version Arbitration
 
-`MultiplexerDebugInfo` may be attached to discovery, health, snapshots, RPC requests, RPC responses, and events:
+`MultiplexerDebugInfo` may be attached to health/register handshakes, snapshots, RPC requests, RPC responses, and events:
 
 ```ts
 type MultiplexerDebugInfo = {
@@ -457,11 +441,11 @@ type MultiplexerDebugInfo = {
 
 Every field is optional and diagnostic only. `processId` identifies the process that generated the context, and `timestamp` is its Unix timestamp in milliseconds. Ordinary `DebugRouterConnector` construction does not configure this context, so normal protocol messages omit `debugInfo`; internal embedding and tests can opt in, after which producers add current process and timestamp information. Consumers must not use `debugInfo` for feature detection or compatibility decisions.
 
-The former `capabilities` field is removed. Actual compatibility arbitration uses the required top-level `protocolVersion` and optional `minSupportedProtocolVersion` in discovery and health. Version strings used only for troubleshooting remain inside `MultiplexerDebugInfo` rather than appearing as standalone protocol fields.
+Actual compatibility arbitration uses the required top-level `protocolVersion` in `health-response`. A normal health response carries no pid or instance token. Version strings used only for troubleshooting remain inside `MultiplexerDebugInfo` rather than appearing as standalone protocol fields.
 
-### 8.5 Connection Trace Is Not a Control Protocol
+### 8.6 Connection Trace Is Not a Control Protocol
 
-Connection trace is daemon-owned and is not part of `snapshot` or the control protocol. `MultiplexerHost` is the only owner that constructs `ConnectionTraceRecorder` from `connectionTrace`, passes that same instance to the `PhysicalConnector` it creates, records whole-chain connection facts, and closes the recorder. It does not reuse a recorder from an injected `PhysicalConnector` or an incoming `traceRecorder` option. In addition to the legacy device, runtime, and WebSocket-client connection facts, Host records daemon lifecycle and stop triggers, control-socket connections, shared WebSocket-server lifecycle, and legacy-ownership acquisition or loss. Control-socket events include the `controlId` and the resulting active-connection count; server and ownership events carry their endpoint or owner metadata. The Connector facade no longer exposes `getConnectionTrace()` or `onConnectionTrace()`, and the daemon exposes no trace query/subscription RPC or trace control event. The recorder's existing buffer, listener, and query capabilities remain available internally for now but are not exposed across processes.
+Connection trace is daemon-owned and is not part of `snapshot` or the control protocol. `MultiplexerDaemonHost` is the only owner that constructs `ConnectionTraceRecorder` from `connectionTrace`, passes that same instance to the `PhysicalConnector` it creates, records whole-chain connection facts, and closes the recorder. It does not reuse a recorder from an injected `PhysicalConnector` or an incoming `traceRecorder` option. In addition to the legacy device, runtime, and WebSocket-client connection facts, Host records daemon lifecycle and stop triggers, control-socket connections, shared WebSocket-server lifecycle, and legacy-ownership acquisition or loss. Control-socket events include the `controlId` and the resulting active-connection count; server and ownership events carry their endpoint or owner metadata. The Connector facade no longer exposes `getConnectionTrace()` or `onConnectionTrace()`, and the daemon exposes no trace query/subscription RPC or trace control event. The recorder's existing buffer, listener, and query capabilities remain available internally for now but are not exposed across processes.
 
 Trace configuration is daemon-startup-global. The first Connector that actually starts the daemon determines `connectionTrace`; later Connectors reuse that daemon and cannot replace its recorder configuration until the daemon restarts. The daemon constructs the recorder using the original `ConnectionTraceOptions` rules and `process.env.DriverConnectionTracePath`, so the default remains disabled when neither provides an output. A string `connectionTrace.output` is converted to an absolute path and serialized to the daemon. A `WritableStream` remains valid for an in-process `PhysicalConnector`, but cannot cross the Multiplexer process boundary, so the facade ignores that output and logs a warning while forwarding the other trace options. `MultiplexerDaemonManager` explicitly removes `traceRecorder` from daemon startup serialization; the daemon entry also rejects a manually supplied recorder instance.
 
@@ -499,11 +483,11 @@ Local mirror synchronization rules:
 
 ## 10. WebSocket Frontend Path
 
-`WebSocketController` has been decoupled from the concrete `DebugRouterConnector` class and depends on the structural `WebSocketControllerHost`. In the current Multiplexer implementation, that host is the daemon-side `MultiplexerHost`.
+`WebSocketController` has been decoupled from the concrete `DebugRouterConnector` class and depends on the structural `WebSocketControllerHost`. In the current Multiplexer implementation, that host is the daemon-side `MultiplexerDaemonHost`.
 
 `startWSServer` RPC runs inside the daemon:
 
-1. Select a port from `websocketOption.port` or default `19783`, using `detect-port` to avoid conflicts.
+1. Start from the legacy default port `19783` and use `detect-port` to avoid conflicts. The public `websocketOption.port` field is retained but ignored, matching the legacy Connector behavior.
 2. Use `ip.address()` to build the host and return `WebSocketServerInfo`.
 3. Create `WebSocketController` and listen on `/mdevices/page/android`.
 
@@ -519,7 +503,7 @@ WebSocket client handshake:
 
 Message paths:
 
-- Driver frontend sends `Customized` to a target runtime: `WebSocketClient` extracts the target `client_id`, calls `WebSocketController.sendMessageToApp(id, message, fromWebClientId)`, and enters `MultiplexerHost.handleWebSocketMessage()`. Host selects either a WebSocket app client (WiFi) or `PhysicalConnector.usbClients` (USB) by client id.
+- Driver frontend sends `Customized` to a target runtime: `WebSocketClient` extracts the target `client_id`, calls `WebSocketController.sendMessageToApp(id, message, fromWebClientId)`, and enters `MultiplexerDaemonHost.handleWebSocketMessage()`. Host selects either a WebSocket app client (WiFi) or `PhysicalConnector.usbClients` (USB) by client id.
 - WebSocket app client sends a message to frontend: `WebSocketClient` calls `handleWebSocketAppMessage()`. Host passes it to the transport-independent `handleRuntimeMessage(appClientId, message, "websocket-runtime")`, so WiFi and USB share routing while retaining an explicit message source.
 - `ClientList` is triggered by Driver frontends and returns current WebSocket app clients and USB runtime clients. USB runtime clients use `network: "USB"`; WebSocket app clients use `network: "WiFi"`.
 
@@ -577,7 +561,7 @@ Outbound handling:
 
 1. Host parses the outer JSON.
 2. Ignore `UsbConnect` and `UsbConnectAck`.
-3. If `data.data.client_id` is non-zero/truthy, rewrite it to `-1` before sending to runtime.
+3. If `data.data.client_id` is non-zero/truthy, rewrite it according to the selected transport: USB receives `-1`, while a WiFi runtime receives its actual daemon-assigned `clientId`.
 4. Recognize the Customized payload from `data.data.message`, supporting both string and object message forms.
 5. Create a pending route only when the payload contains a safe integer `id`.
 6. Host allocates `globalMessageId`, rewrites the original ID to the global ID, and writes the mapping into `PendingRouteTable`.
@@ -587,11 +571,11 @@ Inbound handling:
 
 1. Host receives a runtime message and parses the Customized payload.
 2. If the payload has a safe integer ID, `take()` the route from `PendingRouteTable` by global ID.
-3. On route hit, restore the frontend original ID and restore sender/client_id to the real runtime client ID.
-4. If a control route has `resolve`, it came from `sendMessageWithReply()`; resolve with the complete restored `ResponseMessageType`. The Connector-side mirror extracts the inner message only when implementing its public `sendCustomizedMessage()` helper. Otherwise, send a targeted `client-message` event back to the specified control, with source `usb-runtime` or `websocket-runtime`.
-5. WebSocket routes use `sendMessageToWebClient(webClientId, message)` to send only to the original Driver frontend.
+3. On route hit, restore the original request ID and produce two representations. The Web routing representation also rewrites `sender`/`client_id` to the real daemon-assigned runtime ID. The Connector compatibility representation preserves the restored request ID without exposing that Web identity rewrite.
+4. If a control route has `resolve`, it came from `sendMessageWithReply()`; parse the Connector representation into a complete `ResponseMessageType` and restore its `client_id`. The Connector-side mirror extracts the inner message only when implementing its public `sendCustomizedMessage()` helper. Otherwise, send the Connector representation in a targeted `client-message` event, with source `usb-runtime` or `websocket-runtime`.
+5. WebSocket routes use the Web representation with `sendMessageToWebClient(webClientId, message)`, so only the original Driver frontend receives it.
 6. If a message has a response ID but no route matches, drop it to avoid leaking one frontend's response to other frontends.
-7. If a message has no response ID, treat it as an SDK-initiated event: rewrite runtime client ID, broadcast to WebSocket Driver frontends, and broadcast a `client-message` event with the matching runtime source.
+7. If a message has no response ID, treat it as an SDK-initiated event. WebSocket Driver frontends and the notification cache use a representation rewritten with the real runtime ID; Connector controls receive the runtime's original message string byte-for-byte, while `client-message` separately carries the matching source and runtime ID.
 
 Route cleanup:
 
@@ -693,7 +677,7 @@ The corresponding sequence is:
 sequenceDiagram
     participant A as Frontend A
     participant B as Frontend B
-    participant H as MultiplexerHost
+    participant H as MultiplexerDaemonHost
     participant T as MemoizedNotificationQueryTable
     participant S as SDK runtime
 
@@ -796,10 +780,10 @@ multiplexerDaemonIdleTimeout = 600000ms
 
 Host idle detection only counts two upper-layer consumers:
 
-1. Control WebSocket connections, meaning connector API users.
+1. Registered local control socket connections, meaning connector API users.
 2. WebSocket frontends whose type is `Driver`.
 
-When both counts are 0, Host starts the idle timer. When the timer expires, Host calls the daemon idle handler. The daemon runs `stop()` and the entry process exits. If a new control connection or Driver frontend connects during the idle window, the timer is cancelled.
+When both counts are 0, Host starts the idle timer. When the timer expires, Host requests process shutdown through the handler installed by entry. Entry stops Host and then exits the daemon process. If a new control connection or Driver frontend connects during the idle window, the timer is cancelled.
 
 WiFi runtime/app connections are not consumers for idle ownership. Connecting, disconnecting, or continuing to use a phone over WiFi does not cancel or restart the idle timer; without a Connector control client or Driver frontend, the daemon exits after the configured timeout and closes the shared WebSocket server as part of `stop()`.
 
@@ -807,7 +791,7 @@ If `multiplexerDaemonIdleTimeout` is negative, non-finite, or not configured in 
 
 ### 13.3 Daemon Replacement/Yield
 
-When a connector finds an outdated or unhealthy daemon that must be replaced, Manager first requests graceful daemon shutdown through the `shutdownDaemon` RPC. Host calls its shutdown handler, and the daemon runs `stop()` to clean heartbeat, discovery, lock, control server, WebSocket server, and physical connector. Manager only tries SIGTERM/SIGKILL if the daemon does not exit in time.
+When a connector finds an idle outdated daemon or an unhealthy daemon that must be replaced, Manager identifies the process through the data directory's daemon marker and requests graceful shutdown through the control protocol when possible. Host forwards that request to entry; entry stops Host-owned resources and exits the process. If graceful shutdown cannot complete, Manager falls back to process-level termination and stale endpoint cleanup. An outdated daemon with an active Connector or Driver frontend is not stopped automatically. This flow does not rely on a daemon-owned discovery or lock file.
 
 ### 13.4 Unknown Response ID
 
@@ -817,22 +801,22 @@ When Host receives a runtime response with a valid response ID but no matching r
 
 Current Multiplexer-related `DebugRouterConnectorOption` fields:
 
-| Option                         | Purpose                                                                      |
-| ------------------------------ | ---------------------------------------------------------------------------- |
-| `multiplexerDaemonIdleTimeout` | Daemon idle shutdown timeout. Facade default is 600000 ms.                   |
-| `multiplexerStartupTimeout`    | Timeout for waiting for daemon readiness. Default is 5000 ms.                |
-| `multiplexerStaleTimeout`      | Timeout for judging discovery heartbeat as stale. Facade default is 5000 ms. |
-| `multiplexerHeartbeatInterval` | Daemon discovery heartbeat interval. Default is 1000 ms.                    |
-| `multiplexerRpcTimeout`        | Default control RPC timeout. Default is 5000 ms.                             |
-| `multiplexerRootDir`           | Multiplexer root directory. Default is `~/.DebugRouterConnector`.            |
-| `multiplexerDataDir`           | Multiplexer data directory. Takes precedence over root dir.                  |
-| `multiplexerDaemonEntry`       | Daemon entry js path, used by tests or special packaging scenarios.          |
-| `multiplexerLegacyDriverDir`   | Directory containing the legacy `LatestDriverProcess`.                       |
-| `forceRespawnDaemon`           | Debug/test-only one-shot replacement using this Connector's exact options.   |
-| `websocketOption.port`         | Desired daemon WebSocket server port. Default is 19783.                      |
-| `websocketOption.roomId`       | Room id returned by WebSocket `RoomJoined`.                                  |
+| Option                         | Purpose                                                                                              |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `multiplexerDaemonIdleTimeout` | Daemon idle shutdown timeout. Facade default is 600000 ms.                                           |
+| `multiplexerStartupTimeout`    | Timeout for waiting for daemon readiness. Default is 5000 ms.                                        |
+| `multiplexerRpcTimeout`        | Default control RPC timeout. Default is 5000 ms.                                                     |
+| `multiplexerRootDir`           | Multiplexer root directory. Default is `~/.DebugRouterConnector`.                                    |
+| `multiplexerDataDir`           | Multiplexer data directory. Takes precedence over root dir.                                          |
+| `multiplexerDaemonEntry`       | Daemon entry js path, used by tests or special packaging scenarios.                                  |
+| `multiplexerLegacyDriverDir`   | Directory containing the legacy `LatestDriverProcess`.                                               |
+| `enableWebSocket`              | Enables WebSocket exposure for this facade; daemon startup behavior is shared.                       |
+| `connectionTrace`              | Daemon-global trace configuration; only serializable string output paths cross the process boundary. |
+| `forceRespawnDaemon`           | Debug/test-only one-shot replacement using this Connector's exact options.                           |
+| `websocketOption.port`         | Retained for the legacy option shape but ignored; selection starts at 19783.                         |
+| `websocketOption.roomId`       | Room id returned by WebSocket `RoomJoined`.                                                          |
 
-`MultiplexerHostOption.memoizedNotificationTtlMs` controls the daemon-side pending and cache TTL and defaults to 1000 ms. It is currently an internal Host option used for embedding and deterministic tests, not a public `DebugRouterConnectorOption` propagated through daemon startup.
+`MultiplexerDaemonHostOption.memoizedNotificationTtlMs` controls the daemon-side pending and cache TTL and defaults to 1000 ms. It is currently an internal Host option used for embedding and deterministic tests, not a public `DebugRouterConnectorOption` propagated through daemon startup.
 
 The daemon-side `PhysicalConnector` receives transport endpoints and serializable options such as `adbHostPort`, `hdcHostPort`, `usbConnectOpt`, `networkDeviceOpt`, and `connectionTrace`. In the normal shared-daemon path, generally available platform options are enabled in the daemon and each Connector filters the devices, clients, snapshots, and events it exposes according to its own option flags. Only `forceRespawnDaemon` makes the replacement daemon use that Connector's `manualConnect`, WebSocket, and platform enable flags exactly. The daemon entry validates `connectionTrace.enabled` as boolean, `connectionTrace.output` as a string path, and `connectionTrace.bufferSize` as a non-negative finite number; recorder instances are rejected. `reportService` is not serialized across the process boundary; the daemon creates its own local report service.
 
@@ -841,9 +825,9 @@ The public facade no longer treats `enableMultiplexer`, `enableProxy`, `proxyDae
 Protocol compatibility rules:
 
 1. `daemon.protocolVersion === connector.protocolVersion`: reuse directly.
-2. `daemon.protocolVersion > connector.protocolVersion` and `connector.protocolVersion >= daemon.minSupportedProtocolVersion`: reuse the newer daemon; old connector only calls RPCs and events it knows.
-3. `connector.protocolVersion < daemon.minSupportedProtocolVersion`: connector rejects connection and asks for upgrade. It does not clean up the newer daemon.
-4. `daemon.protocolVersion < connector.protocolVersion`: connector treats daemon as outdated and runs replacement.
+2. `daemon.protocolVersion > connector.protocolVersion`: reuse the newer daemon; the Connector only calls RPCs and events it knows.
+3. `daemon.protocolVersion < connector.protocolVersion` and `daemon.isInUse === false`: connector treats the daemon as outdated and runs replacement.
+4. `daemon.protocolVersion < connector.protocolVersion` and `daemon.isInUse === true`: connector reports that active connections block the upgrade and leaves the daemon running.
 
 ## 15. Typical Flows
 
@@ -851,16 +835,16 @@ Protocol compatibility rules:
 
 1. Facade creates discovery, manager, and daemon client.
 2. `connectDevices()` triggers `daemonClient.connect()`.
-3. Manager finds no available daemon and acquires `spawn.lock`.
+3. Health probe cannot reach the fixed endpoint, so Manager acquires `spawn.lock`.
 4. Manager spawns detached daemon entry.
-5. Daemon acquires `daemon.lock`, starts Host/control server, and writes `daemon.json`.
-6. Connector connects to the control WebSocket and receives the initial `snapshot`.
+5. Entry constructs and starts Host; Host starts the control server at the fixed endpoint without holding a runtime lock.
+6. Connector sends `register`, receives `register-response`, and then receives the initial `snapshot`.
 7. Facade uses the `connectDevices` RPC to ask Host to start physical device discovery.
 
 ### 15.2 Later Connector Startup
 
-1. Facade reads existing `daemon.json`.
-2. Discovery is fresh and health is OK, so it connects to the existing control server.
+1. Facade probes the fixed local endpoint with a framed `health` request.
+2. Health and protocol arbitration succeed, so it registers with the existing control server.
 3. The new control connection receives current snapshot.
 4. Later physical-device and USB-runtime lifecycle changes are broadcast as snapshots to all control clients. USB/WiFi runtime routing shares one processing strategy and emits `client-message` with the matching source. Connector facades expose WebSocket lifecycle and message state only after requesting `startWSServer()`.
 
@@ -893,13 +877,13 @@ Protocol compatibility rules:
 
 The current test layers cover the main behavior introduced by this design:
 
-| Layer                             | Current coverage                                                                                                                                                                                                           |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unit                              | Host routing, WebSocket parsing/error containment, requester-scoped mirrors, `MultiplexerWebSocketClient`, connection trace ownership, overlapping client ids, and ownership-loss state cleanup.                           |
-| Integration                       | Concurrent daemon startup, version replacement, reconnect/snapshot convergence, routing isolation, daemon idle lifecycle, daemon-owned connection trace, WiFi runtime behavior, and legacy ownership preemption/reacquire. |
-| Package-entry E2E without devices | Shared daemon/facade behavior, WebSocket routing, WiFi runtime registration and proxy APIs, Driver preservation during ownership loss, and snapshot/`ClientList` convergence.                                              |
-| Real-device USB E2E               | Android/iOS discovery, runtime watcher recovery, request-response routing, legacy ownership preemption, and stress/churn flows through `real_device.js` and `real_device_stress.js`.                                       |
-| Real-device WiFi E2E              | Android WiFi registration, public lifecycle/mirrors, Driver and Connector round trips, proxy calls, and disconnect cleanup through `real_device_wifi.js`.                                                                  |
+| Layer                             | Current coverage                                                                                                                                                                                                                                                                             |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit                              | Control framing/limits/invalid input, first-message handshake, health classification/retry, Host routing, WebSocket parsing/error containment, requester-scoped mirrors, `MultiplexerWebSocketClient`, connection trace ownership, overlapping client ids, and ownership-loss state cleanup. |
+| Integration                       | Fixed-endpoint daemon discovery, concurrent daemon startup, version replacement, reconnect/snapshot convergence, routing isolation, daemon idle lifecycle, daemon-owned connection trace, WiFi runtime behavior, and legacy ownership preemption/reacquire.                                  |
+| Package-entry E2E without devices | Shared daemon/facade behavior, WebSocket routing, WiFi runtime registration and proxy APIs, Driver preservation during ownership loss, and snapshot/`ClientList` convergence.                                                                                                                |
+| Real-device USB E2E               | Android/iOS discovery, runtime watcher recovery, request-response routing, legacy ownership preemption, and stress/churn flows through `real_device.js` and `real_device_stress.js`.                                                                                                         |
+| Real-device WiFi E2E              | Android WiFi registration, public lifecycle/mirrors, Driver and Connector round trips, proxy calls, and disconnect cleanup through `real_device_wifi.js`.                                                                                                                                    |
 
 Protocol validator unit tests cover every RPC method's parameter and method-aware result branch, all three control event variants, snapshot DTOs, optional diagnostic fields, malformed envelopes, and the exact empty-object contracts. This keeps the MR1 protocol foundation independently reviewable before the later daemon and facade implementation slices.
 

--- a/debug_router_connector/src/multiplexer/transport/MultiplexerControlTransport.ts
+++ b/debug_router_connector/src/multiplexer/transport/MultiplexerControlTransport.ts
@@ -1,0 +1,255 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Socket } from "net";
+// @ts-ignore
+import * as bufferpack from "bufferpack";
+import { defaultLogger } from "../../utils/logger";
+
+const FRAME_PREFIX = "$MUX";
+const FRAME_HEADER_FORMAT = "! 4s I";
+const FRAME_HEADER_SIZE = 8;
+export const DEFAULT_MULTIPLEXER_CONTROL_MAX_FRAME_SIZE = 16 * 1024 * 1024;
+export const DEFAULT_MULTIPLEXER_CONTROL_MAX_BUFFER_SIZE = 32 * 1024 * 1024;
+
+export type MultiplexerControlTransportOption = {
+  maxFrameSize?: number;
+  maxBufferSize?: number;
+};
+
+export class MultiplexerControlTransportError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "MultiplexerControlTransportError";
+    this.code = code;
+  }
+}
+
+export class MultiplexerControlTransport {
+  private readonly socket: Socket;
+  private readonly maxFrameSize: number;
+  private readonly maxBufferSize: number;
+  private connectListener: (() => void) | undefined;
+  private messageListener: ((message: unknown) => void) | undefined;
+  private readonly closeListeners = new Set<(error?: Error) => void>();
+  private buffer = Buffer.alloc(0);
+  private closeError: Error | undefined;
+
+  constructor(socket: Socket, option: MultiplexerControlTransportOption = {}) {
+    this.socket = socket;
+    this.maxFrameSize =
+      option.maxFrameSize ?? DEFAULT_MULTIPLEXER_CONTROL_MAX_FRAME_SIZE;
+    this.maxBufferSize =
+      option.maxBufferSize ?? DEFAULT_MULTIPLEXER_CONTROL_MAX_BUFFER_SIZE;
+
+    socket.on("connect", this.handleSocketConnect);
+    socket.on("data", this.handleData);
+    socket.on("end", this.handleEnd);
+    socket.on("close", this.handleSocketClose);
+    socket.on("error", this.handleSocketError);
+  }
+
+  get closed(): boolean {
+    return this.socket.destroyed;
+  }
+
+  get writable(): boolean {
+    return !this.closed && this.socket.writable;
+  }
+
+  send(message: unknown): void {
+    if (!this.writable) {
+      throw new Error("Multiplexer control transport is not writable");
+    }
+
+    const serialized = JSON.stringify(message);
+    if (serialized === undefined) {
+      throw new Error("Multiplexer control message is not JSON serializable");
+    }
+
+    const payload = Buffer.from(serialized, "utf8");
+    if (payload.length > this.maxFrameSize) {
+      throw new MultiplexerControlTransportError(
+        "frame-too-large",
+        `Multiplexer control frame exceeds ${this.maxFrameSize} bytes`,
+      );
+    }
+
+    const frame = bufferpack.pack(`${FRAME_HEADER_FORMAT} ${payload.length}A`, [
+      FRAME_PREFIX,
+      payload.length,
+      payload,
+    ]);
+    this.socket.write(frame);
+  }
+
+  onConnect(listener: () => void): () => void {
+    this.connectListener = listener;
+    return () => {
+      this.connectListener = undefined;
+    };
+  }
+
+  onMessage(listener: (message: unknown) => void): () => void {
+    this.messageListener = listener;
+    return () => {
+      this.messageListener = undefined;
+    };
+  }
+
+  onClose(listener: (error?: Error) => void): () => void {
+    if (this.closed) {
+      listener(this.closeError);
+      return () => {};
+    }
+
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  end(): Promise<void> {
+    if (this.closed) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.onClose(() => resolve());
+      this.socket.end();
+    });
+  }
+
+  destroy(error?: Error): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closeError = error ?? this.closeError;
+    this.socket.destroy();
+  }
+
+  private readonly handleData = (chunk: Buffer): void => {
+    if (this.closed || chunk.length === 0) {
+      return;
+    }
+
+    if (this.buffer.length + chunk.length > this.maxBufferSize) {
+      this.destroy(
+        new MultiplexerControlTransportError(
+          "buffer-too-large",
+          `Multiplexer control buffer exceeds ${this.maxBufferSize} bytes`,
+        ),
+      );
+      return;
+    }
+
+    this.buffer =
+      this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    this.parseFrames();
+  };
+
+  private parseFrames(): void {
+    while (!this.closed && this.buffer.length >= FRAME_HEADER_SIZE) {
+      const frameStart = this.buffer.indexOf(FRAME_PREFIX);
+      if (frameStart < 0) {
+        const discardedLength = this.buffer.length - FRAME_PREFIX.length;
+        this.buffer = this.buffer.subarray(discardedLength);
+        return;
+      }
+
+      this.buffer = this.buffer.subarray(frameStart);
+
+      if (this.buffer.length < FRAME_HEADER_SIZE) {
+        return;
+      }
+
+      const [, payloadLength] = bufferpack.unpack(
+        FRAME_HEADER_FORMAT,
+        this.buffer,
+        0,
+      );
+      if (payloadLength === 0) {
+        const error = new MultiplexerControlTransportError(
+          "invalid-frame",
+          "Multiplexer control frame payload length must be greater than zero",
+        );
+        defaultLogger.warn(error.message);
+        this.destroy(error);
+        return;
+      }
+      if (payloadLength > this.maxFrameSize) {
+        const error = new MultiplexerControlTransportError(
+          "frame-too-large",
+          `Multiplexer control frame exceeds ${this.maxFrameSize} bytes`,
+        );
+        defaultLogger.warn(error.message);
+        this.destroy(error);
+        return;
+      }
+
+      const frameLength = FRAME_HEADER_SIZE + payloadLength;
+      if (this.buffer.length < frameLength) {
+        return;
+      }
+
+      const payload = this.buffer.subarray(FRAME_HEADER_SIZE, frameLength);
+
+      let message: unknown;
+      try {
+        message = JSON.parse(payload.toString("utf8"));
+      } catch (error) {
+        const frameError = new MultiplexerControlTransportError(
+          "invalid-frame",
+          `Failed to parse multiplexer control message: ${String(error)}`,
+        );
+        defaultLogger.warn(frameError.message);
+        this.destroy(frameError);
+        return;
+      }
+
+      this.buffer = this.buffer.subarray(frameLength);
+      this.messageListener?.(message);
+    }
+  }
+
+  private readonly handleSocketConnect = (): void => {
+    this.connectListener?.();
+  };
+
+  private readonly handleEnd = (): void => {
+    if (this.buffer.length > 0 && !this.closeError) {
+      this.closeError = new MultiplexerControlTransportError(
+        "incomplete-frame",
+        "Multiplexer control socket ended with an incomplete frame",
+      );
+    }
+    this.socket.destroy();
+  };
+
+  private readonly handleSocketClose = (): void => {
+    this.notifyClose();
+  };
+
+  private readonly handleSocketError = (error: Error): void => {
+    this.closeError = error;
+    this.socket.destroy();
+  };
+
+  private notifyClose(): void {
+    this.socket.off("connect", this.handleSocketConnect);
+    this.socket.off("data", this.handleData);
+    this.socket.off("end", this.handleEnd);
+    this.socket.off("close", this.handleSocketClose);
+    this.socket.off("error", this.handleSocketError);
+    this.buffer = Buffer.alloc(0);
+    this.connectListener = undefined;
+
+    for (const listener of Array.from(this.closeListeners)) {
+      listener(this.closeError);
+    }
+    this.closeListeners.clear();
+    this.messageListener = undefined;
+  }
+}

--- a/test/unit/multiplexer/transport/MultiplexerControlTransport.test.js
+++ b/test/unit/multiplexer/transport/MultiplexerControlTransport.test.js
@@ -1,0 +1,235 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("assert");
+const { EventEmitter } = require("events");
+
+const {
+  MultiplexerControlTransport,
+  MultiplexerControlTransportError,
+} = require("../../../../debug_router_connector/dist/cjs/src/multiplexer/transport/MultiplexerControlTransport");
+
+const FRAME_PREFIX = Buffer.from("$MUX", "ascii");
+const FRAME_HEADER_SIZE = FRAME_PREFIX.length + 4;
+
+class FakeSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.writable = true;
+    this.destroyed = false;
+    this.writes = [];
+    this.writeResult = true;
+  }
+
+  write(data) {
+    this.writes.push(Buffer.from(data));
+    if (this.writeError) {
+      throw this.writeError;
+    }
+    return this.writeResult;
+  }
+
+  end() {
+    this.writable = false;
+    this.destroyed = true;
+    this.emit("close");
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.writable = false;
+    this.destroyed = true;
+    this.emit("close");
+  }
+}
+
+function frame(value) {
+  const payload = Buffer.from(JSON.stringify(value));
+  const result = Buffer.alloc(FRAME_HEADER_SIZE + payload.length);
+  FRAME_PREFIX.copy(result, 0);
+  result.writeUInt32BE(payload.length, FRAME_PREFIX.length);
+  payload.copy(result, FRAME_HEADER_SIZE);
+  return result;
+}
+
+describe("MultiplexerControlTransport", function () {
+  it("parses split headers, split payloads, and multiple frames", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const messages = [];
+    transport.onMessage((message) => messages.push(message));
+
+    const first = frame({ id: 1 });
+    const second = frame({ id: 2 });
+    socket.emit("data", first.subarray(0, 2));
+    socket.emit("data", first.subarray(2, 7));
+    assert.deepStrictEqual(messages, []);
+    socket.emit("data", Buffer.concat([first.subarray(7), second]));
+
+    assert.deepStrictEqual(messages, [{ id: 1 }, { id: 2 }]);
+  });
+
+  it("hands off the message listener between frames in the same chunk", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const messages = [];
+    transport.onMessage((message) => {
+      messages.push(["handshake", message]);
+      transport.onMessage((nextMessage) => {
+        messages.push(["steady", nextMessage]);
+      });
+    });
+
+    socket.emit("data", Buffer.concat([frame({ id: 1 }), frame({ id: 2 })]));
+
+    assert.deepStrictEqual(messages, [
+      ["handshake", { id: 1 }],
+      ["steady", { id: 2 }],
+    ]);
+  });
+
+  it("writes complete ordered frames", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+
+    transport.send({ id: 1 });
+    transport.send({ id: 2 });
+
+    assert.deepStrictEqual(socket.writes, [frame({ id: 1 }), frame({ id: 2 })]);
+  });
+
+  it("closes on a zero or oversized incoming payload length", function () {
+    const zeroLengthSocket = new FakeSocket();
+    const zeroLengthTransport = new MultiplexerControlTransport(
+      zeroLengthSocket
+    );
+    let zeroLengthError;
+    zeroLengthTransport.onClose((error) => {
+      zeroLengthError = error;
+    });
+    const zeroLengthFrame = Buffer.alloc(FRAME_HEADER_SIZE);
+    FRAME_PREFIX.copy(zeroLengthFrame, 0);
+    zeroLengthSocket.emit("data", zeroLengthFrame);
+
+    assert.strictEqual(zeroLengthTransport.closed, true);
+    assert.strictEqual(zeroLengthError.code, "invalid-frame");
+
+    const oversizedSocket = new FakeSocket();
+    const oversizedTransport = new MultiplexerControlTransport(
+      oversizedSocket,
+      { maxFrameSize: 4 }
+    );
+    let oversizedError;
+    oversizedTransport.onClose((error) => {
+      oversizedError = error;
+    });
+    const oversizedHeader = Buffer.alloc(FRAME_HEADER_SIZE);
+    FRAME_PREFIX.copy(oversizedHeader, 0);
+    oversizedHeader.writeUInt32BE(5, FRAME_PREFIX.length);
+    oversizedSocket.emit("data", oversizedHeader);
+
+    assert.strictEqual(oversizedTransport.closed, true);
+    assert.strictEqual(oversizedError.code, "frame-too-large");
+  });
+
+  it("closes on invalid JSON without parsing later frames", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const messages = [];
+    let closeError;
+    transport.onMessage((message) => messages.push(message));
+    transport.onClose((error) => {
+      closeError = error;
+    });
+    const invalidPayload = Buffer.from("{");
+    const invalidFrame = Buffer.alloc(FRAME_HEADER_SIZE + 1);
+    FRAME_PREFIX.copy(invalidFrame, 0);
+    invalidFrame.writeUInt32BE(1, FRAME_PREFIX.length);
+    invalidPayload.copy(invalidFrame, FRAME_HEADER_SIZE);
+    socket.emit("data", Buffer.concat([invalidFrame, frame({ id: 1 })]));
+
+    assert.deepStrictEqual(messages, []);
+    assert.strictEqual(transport.closed, true);
+    assert.strictEqual(closeError.code, "invalid-frame");
+  });
+
+  it("discards interference before a split frame header", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const messages = [];
+    transport.onMessage((message) => messages.push(message));
+
+    const validFrame = frame({ id: 1 });
+    socket.emit("data", Buffer.from("interference$M", "ascii"));
+    assert.deepStrictEqual(messages, []);
+    socket.emit("data", validFrame.subarray(2));
+
+    assert.deepStrictEqual(messages, [{ id: 1 }]);
+    assert.strictEqual(transport.closed, false);
+  });
+
+  it("discards interference between valid frames", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const messages = [];
+    transport.onMessage((message) => messages.push(message));
+
+    socket.emit(
+      "data",
+      Buffer.concat([
+        frame({ id: 1 }),
+        Buffer.from("interference", "ascii"),
+        frame({ id: 2 }),
+      ])
+    );
+
+    assert.deepStrictEqual(messages, [{ id: 1 }, { id: 2 }]);
+    assert.strictEqual(transport.closed, false);
+  });
+
+  it("rejects oversized outgoing frames", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket, {
+      maxFrameSize: 4,
+    });
+
+    assert.throws(
+      () => transport.send(12345),
+      (error) =>
+        error instanceof MultiplexerControlTransportError &&
+        error.code === "frame-too-large"
+    );
+  });
+
+  it("rejects send on non-writable sockets and propagates sync write errors", function () {
+    const closedSocket = new FakeSocket();
+    closedSocket.writable = false;
+    const closedTransport = new MultiplexerControlTransport(closedSocket);
+    assert.throws(() => closedTransport.send({}));
+
+    const errorSocket = new FakeSocket();
+    const writeError = new Error("write failed");
+    errorSocket.writeError = writeError;
+    const errorTransport = new MultiplexerControlTransport(errorSocket);
+    assert.throws(
+      () => errorTransport.send({}),
+      (error) => error === writeError
+    );
+  });
+
+  it("notifies close once across error, end, close, and destroy", function () {
+    const socket = new FakeSocket();
+    const transport = new MultiplexerControlTransport(socket);
+    const closes = [];
+    transport.onClose((error) => closes.push(error));
+
+    const socketError = new Error("boom");
+    socket.emit("error", socketError);
+    socket.emit("end");
+    socket.emit("close");
+    transport.destroy(new Error("later"));
+
+    assert.deepStrictEqual(closes, [socketError]);
+  });
+});


### PR DESCRIPTION
Add length-prefixed control transport, frame validation, ordered writes, connection lifecycle handling, and focused transport coverage for the staged multiplexer control channel migration.

doc: https://github.com/naitir64/debug-router/blob/multiplexer/agents/DebugRouter%20Multiplexer%20Technical%20Design.md

TEST: cd debug_router_connector && npx tsc -p tsconfig.json --noEmit && npm run test:multiplexer