### PR TITLE
[Feature] Add multiplexer daemon health discovery

### DIFF
--- a/debug_router_connector/src/multiplexer/client/MultiplexerDiscovery.ts
+++ b/debug_router_connector/src/multiplexer/client/MultiplexerDiscovery.ts
@@ -1,0 +1,183 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createConnection } from "net";
+import {
+  MultiplexerDebugInfo,
+  MultiplexerHealthRequest,
+  MultiplexerHealthResponse,
+  isMultiplexerHandshakeErrorResponse,
+  isMultiplexerHealthResponse,
+} from "../protocol";
+import {
+  MultiplexerControlTransport,
+  MultiplexerControlTransportError,
+} from "../transport/MultiplexerControlTransport";
+
+export const DEFAULT_MULTIPLEXER_HEALTH_CHECK_TIMEOUT = 500;
+
+export type MultiplexerDiscoveryOption = {
+  controlEndpoint: string;
+  localProtocolVersion: number;
+  healthCheckTimeout?: number;
+  debugInfo?: MultiplexerDebugInfo;
+
+  // only used for tests or embedding
+  now?: () => number;
+};
+
+export type MultiplexerDiscoveryValidation =
+  | {
+      status: "usable";
+      reason: "same-version" | "daemon-newer-compatible";
+      daemonProtocolVersion: number;
+      connectorProtocolVersion: number;
+    }
+  | {
+      status: "replace-required";
+      reason: "daemon-older-than-connector";
+      daemonProtocolVersion: number;
+      connectorProtocolVersion: number;
+    }
+  | {
+      status: "unusable";
+      reason: "daemon-upgrade-blocked-by-active-connections";
+      daemonProtocolVersion: number;
+      connectorProtocolVersion: number;
+    }
+  | {
+      status: "unusable";
+      reason: "unreachable" | "timeout" | "invalid-frame" | "invalid-response";
+      error?: Error;
+    };
+
+export class MultiplexerDiscovery {
+  readonly controlEndpoint: string;
+  readonly localProtocolVersion: number;
+  readonly healthCheckTimeout: number;
+
+  private readonly debugInfo?: MultiplexerDebugInfo;
+  private readonly now: () => number;
+
+  constructor(option: MultiplexerDiscoveryOption) {
+    this.controlEndpoint = option.controlEndpoint;
+    this.localProtocolVersion = option.localProtocolVersion;
+    this.healthCheckTimeout =
+      option.healthCheckTimeout ?? DEFAULT_MULTIPLEXER_HEALTH_CHECK_TIMEOUT;
+    this.debugInfo = option.debugInfo;
+    this.now = option.now ?? Date.now;
+  }
+
+  async probeHealth(): Promise<MultiplexerDiscoveryValidation> {
+    return new Promise((resolve) => {
+      const transport = new MultiplexerControlTransport(
+        createConnection(this.controlEndpoint),
+      );
+      let settled = false;
+
+      const finish = (result: MultiplexerDiscoveryValidation): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        unsubscribeConnect();
+        unsubscribeMessage();
+        unsubscribeClose();
+        void transport.end();
+        resolve(result);
+      };
+
+      const handleConnect = (): void => {
+        const debugInfo = this.createDebugInfo();
+        const request: MultiplexerHealthRequest = {
+          kind: "health",
+          ...(debugInfo ? { debugInfo } : {}),
+        };
+        try {
+          transport.send(request);
+        } catch (error) {
+          finish({
+            status: "unusable",
+            reason: "unreachable",
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+        }
+      };
+
+      const unsubscribeMessage = transport.onMessage((message) => {
+        if (isMultiplexerHandshakeErrorResponse(message)) {
+          const error = new Error(message.error.message);
+          error.name = message.error.code;
+          finish({ status: "unusable", reason: "invalid-response", error });
+          return;
+        }
+        if (!isMultiplexerHealthResponse(message)) {
+          finish({ status: "unusable", reason: "invalid-response" });
+          return;
+        }
+        finish(this.compareProtocolVersion(message));
+      });
+      const unsubscribeClose = transport.onClose((error) => {
+        finish({
+          status: "unusable",
+          reason:
+            error instanceof MultiplexerControlTransportError
+              ? "invalid-frame"
+              : "unreachable",
+          ...(error ? { error } : {}),
+        });
+      });
+      const timer = setTimeout(() => {
+        finish({ status: "unusable", reason: "timeout" });
+      }, this.healthCheckTimeout);
+
+      const unsubscribeConnect = transport.onConnect(handleConnect);
+    });
+  }
+
+  compareProtocolVersion(
+    response: MultiplexerHealthResponse,
+  ): MultiplexerDiscoveryValidation {
+    if (response.protocolVersion < this.localProtocolVersion) {
+      if (response.isInUse) {
+        return {
+          status: "unusable",
+          reason: "daemon-upgrade-blocked-by-active-connections",
+          daemonProtocolVersion: response.protocolVersion,
+          connectorProtocolVersion: this.localProtocolVersion,
+        };
+      }
+      return {
+        status: "replace-required",
+        reason: "daemon-older-than-connector",
+        daemonProtocolVersion: response.protocolVersion,
+        connectorProtocolVersion: this.localProtocolVersion,
+      };
+    }
+
+    return {
+      status: "usable",
+      reason:
+        response.protocolVersion === this.localProtocolVersion
+          ? "same-version"
+          : "daemon-newer-compatible",
+      daemonProtocolVersion: response.protocolVersion,
+      connectorProtocolVersion: this.localProtocolVersion,
+    };
+  }
+
+  private createDebugInfo(): MultiplexerDebugInfo | undefined {
+    if (!this.debugInfo) {
+      return undefined;
+    }
+    return {
+      ...this.debugInfo,
+      protocolVersion:
+        this.debugInfo.protocolVersion ?? this.localProtocolVersion,
+      processId: process.pid,
+      timestamp: this.now(),
+    };
+  }
+}

--- a/debug_router_connector/src/multiplexer/protocol/control.ts
+++ b/debug_router_connector/src/multiplexer/protocol/control.ts
@@ -6,6 +6,22 @@ import type { ClientSnapshot, DeviceSnapshot } from "./snapshot";
 import type { RequireMessageType, ResponseMessageType } from "../../utils/type";
 import type { MultiplexerDebugInfo } from "./debuginfo";
 
+export const MULTIPLEXER_PROTOCOL_VERSION = 1;
+
+export type MultiplexerHealthRequest = {
+  kind: "health";
+  debugInfo?: MultiplexerDebugInfo;
+};
+
+// protocolVersion is used for version arbitration when connecting to the Multiplexer daemon.
+export type MultiplexerHealthResponse = {
+  kind: "health-response";
+  ok: true;
+  protocolVersion: number;
+  isInUse: boolean;
+  debugInfo?: MultiplexerDebugInfo;
+};
+
 export type ControlRpcRequest<M extends ControlRpcMethod = ControlRpcMethod> = {
   kind: "rpc";
   id: number;
@@ -34,6 +50,11 @@ export type ControlRpcError = {
   code: string;
   message: string;
   details?: unknown;
+};
+
+export type MultiplexerHandshakeErrorResponse = {
+  kind: "handshake-error-response";
+  error: ControlRpcError;
 };
 
 export type WebSocketServerInfo = {

--- a/debug_router_connector/src/multiplexer/protocol/index.ts
+++ b/debug_router_connector/src/multiplexer/protocol/index.ts
@@ -9,9 +9,13 @@ export type {
   ControlRpcRequest,
   ControlRpcResponse,
   ControlRpcResult,
+  MultiplexerHealthRequest,
+  MultiplexerHealthResponse,
+  MultiplexerHandshakeErrorResponse,
   WebSocketServerInfo,
 } from "./control";
 export type { MultiplexerDebugInfo } from "./debuginfo";
+export { MULTIPLEXER_PROTOCOL_VERSION } from "./control";
 export type { ControlEvent, ControlEventEnvelope } from "./event";
 export type {
   ClientSnapshot,
@@ -25,9 +29,13 @@ export {
   isControlEvent,
   isMultiplexerDebugInfo,
   isControlRpcMethod,
+  isControlRpcParams,
   isControlRpcRequest,
   isControlRpcResponse,
   isDeviceSnapshot,
+  isMultiplexerHealthRequest,
+  isMultiplexerHealthResponse,
+  isMultiplexerHandshakeErrorResponse,
   isNumber,
   isNumberArray,
   isRecord,

--- a/debug_router_connector/src/multiplexer/protocol/validation.ts
+++ b/debug_router_connector/src/multiplexer/protocol/validation.ts
@@ -7,6 +7,9 @@ import type {
   ControlRpcMethod,
   ControlRpcRequest,
   ControlRpcResponse,
+  MultiplexerHandshakeErrorResponse,
+  MultiplexerHealthRequest,
+  MultiplexerHealthResponse,
 } from "./control";
 import type { MultiplexerDebugInfo } from "./debuginfo";
 import type { ControlEvent } from "./event";
@@ -162,6 +165,39 @@ export function isSnapshot(value: unknown): value is Snapshot {
   );
 }
 
+export function isMultiplexerHealthRequest(
+  value: unknown,
+): value is MultiplexerHealthRequest {
+  return (
+    isRecord(value) &&
+    value.kind === "health" &&
+    isOptional(value.debugInfo, isMultiplexerDebugInfo)
+  );
+}
+
+export function isMultiplexerHealthResponse(
+  value: unknown,
+): value is MultiplexerHealthResponse {
+  return (
+    isRecord(value) &&
+    value.kind === "health-response" &&
+    value.ok === true &&
+    isNumber(value.protocolVersion) &&
+    isBoolean(value.isInUse) &&
+    isOptional(value.debugInfo, isMultiplexerDebugInfo)
+  );
+}
+
+export function isMultiplexerHandshakeErrorResponse(
+  value: unknown,
+): value is MultiplexerHandshakeErrorResponse {
+  return (
+    isRecord(value) &&
+    value.kind === "handshake-error-response" &&
+    isControlRpcError(value.error)
+  );
+}
+
 export function isControlRpcRequest(
   value: unknown,
 ): value is ControlRpcRequest {
@@ -228,7 +264,7 @@ export function isControlEvent(value: unknown): value is ControlEvent {
   }
 }
 
-function isControlRpcParams(
+export function isControlRpcParams(
   method: ControlRpcMethod,
   params: unknown,
 ): boolean {

--- a/debug_router_connector/src/multiplexer/utils/paths.ts
+++ b/debug_router_connector/src/multiplexer/utils/paths.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import os from "os";
+import path from "path";
+
+export const DEBUG_ROUTER_CONNECTOR_DATA_DIR_NAME = ".DebugRouterConnector";
+export const MULTIPLEXER_DATA_DIR_NAME = "multiplexer";
+
+export const MULTIPLEXER_CONTROL_SOCKET_NAME = "control.sock";
+
+export type MultiplexerPathOptions = {
+  // Overrides the base DebugRouter connector data directory.
+  rootDir?: string;
+  // Overrides the full multiplexer data directory and takes precedence over rootDir.
+  dataDir?: string;
+};
+
+export function getDefaultMultiplexerRootDir(): string {
+  return path.join(os.homedir(), DEBUG_ROUTER_CONNECTOR_DATA_DIR_NAME);
+}
+
+export function getMultiplexerDataDir(
+  options: MultiplexerPathOptions = {},
+): string {
+  if (options.dataDir) {
+    return options.dataDir;
+  }
+
+  return path.join(
+    options.rootDir ?? getDefaultMultiplexerRootDir(),
+    MULTIPLEXER_DATA_DIR_NAME,
+  );
+}
+
+export function getMultiplexerControlEndpoint(
+  options: MultiplexerPathOptions = {},
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `\\\\.\\pipe\\${getMultiplexerDataDir(options)}`;
+  }
+
+  return path.join(
+    getMultiplexerDataDir(options),
+    MULTIPLEXER_CONTROL_SOCKET_NAME,
+  );
+}

--- a/test/unit/multiplexer/client/MultiplexerDiscovery.test.js
+++ b/test/unit/multiplexer/client/MultiplexerDiscovery.test.js
@@ -1,0 +1,318 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("assert");
+const fs = require("fs");
+const net = require("net");
+const os = require("os");
+const path = require("path");
+const { isDeepStrictEqual } = require("util");
+
+const v1HealthRequest = { kind: "health" };
+const v1HealthResponse = {
+  kind: "health-response",
+  ok: true,
+  protocolVersion: 1,
+  isInUse: false,
+};
+
+const {
+  MultiplexerDiscovery,
+} = require("../../../../debug_router_connector/dist/cjs/src/multiplexer/client/MultiplexerDiscovery");
+const {
+  MULTIPLEXER_PROTOCOL_VERSION,
+} = require("../../../../debug_router_connector/dist/cjs/src/multiplexer/protocol");
+
+const FRAME_PREFIX = Buffer.from("$MUX", "ascii");
+const FRAME_HEADER_SIZE = FRAME_PREFIX.length + 4;
+
+function createTempContext() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "debug-router-health-"));
+  return { dir, endpoint: path.join(dir, "control.sock") };
+}
+
+function frame(value) {
+  const payload = Buffer.from(JSON.stringify(value));
+  const result = Buffer.alloc(FRAME_HEADER_SIZE + payload.length);
+  FRAME_PREFIX.copy(result, 0);
+  result.writeUInt32BE(payload.length, FRAME_PREFIX.length);
+  payload.copy(result, FRAME_HEADER_SIZE);
+  return result;
+}
+
+function receiveFrame(socket) {
+  return new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    const cleanup = () => {
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("end", onEnd);
+    };
+    const rejectFrame = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onData = (chunk) => {
+      try {
+        buffer = Buffer.concat([buffer, chunk]);
+        if (buffer.length < FRAME_HEADER_SIZE) return;
+
+        if (
+          !isDeepStrictEqual(
+            buffer.subarray(0, FRAME_PREFIX.length),
+            FRAME_PREFIX
+          )
+        ) {
+          throw new Error("received an invalid multiplexer frame prefix");
+        }
+        const payloadLength = buffer.readUInt32BE(FRAME_PREFIX.length);
+        if (buffer.length < FRAME_HEADER_SIZE + payloadLength) return;
+
+        cleanup();
+        resolve(
+          JSON.parse(
+            buffer
+              .subarray(FRAME_HEADER_SIZE, FRAME_HEADER_SIZE + payloadLength)
+              .toString()
+          )
+        );
+      } catch (error) {
+        rejectFrame(error);
+      }
+    };
+    const onError = (error) => rejectFrame(error);
+    const onEnd = () =>
+      rejectFrame(new Error("socket ended before receiving a complete frame"));
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("end", onEnd);
+  });
+}
+
+function listen(server, endpoint) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    server.once("error", onError);
+    server.listen(endpoint, () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+describe("MultiplexerDiscovery", function () {
+  const contexts = [];
+  const servers = [];
+
+  function trackServer(server, sockets = new Set()) {
+    const tracked = {
+      async stop() {
+        for (const socket of sockets) socket.destroy();
+        if (server.listening) {
+          await new Promise((resolve) => server.close(resolve));
+        }
+      },
+    };
+    servers.push(tracked);
+    return tracked;
+  }
+
+  afterEach(async function () {
+    await Promise.all(servers.splice(0).map((server) => server.stop()));
+    for (const context of contexts.splice(0)) {
+      fs.rmSync(context.dir, { recursive: true, force: true });
+    }
+  });
+
+  async function startServer(option = {}) {
+    const context = createTempContext();
+    contexts.push(context);
+    const sockets = new Set();
+    const requests = [];
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      void receiveFrame(socket).then(
+        (request) => {
+          requests.push(request);
+          if (
+            option.expectedRequest &&
+            !isDeepStrictEqual(request, option.expectedRequest)
+          ) {
+            socket.end(
+              frame({
+                kind: "handshake-error-response",
+                error: {
+                  code: "unsupported-health-request",
+                  message: "unsupported v1 health request",
+                },
+              })
+            );
+            return;
+          }
+          socket.end(
+            frame(
+              option.response ?? {
+                kind: "health-response",
+                ok: true,
+                protocolVersion: option.protocolVersion ?? 1,
+                isInUse: option.isInUse ?? false,
+              }
+            )
+          );
+        },
+        () => socket.destroy()
+      );
+    });
+    trackServer(server, sockets);
+    await listen(server, context.endpoint);
+    return { ...context, requests };
+  }
+
+  it("[v1 compatibility gate] recognizes a frozen v1 daemon health contract", async function () {
+    const context = await startServer({
+      expectedRequest: v1HealthRequest,
+      response: v1HealthResponse,
+    });
+    const discovery = new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: MULTIPLEXER_PROTOCOL_VERSION,
+    });
+
+    const result = await discovery.probeHealth();
+    assert.strictEqual(
+      result.status,
+      MULTIPLEXER_PROTOCOL_VERSION === 1 ? "usable" : "replace-required"
+    );
+    assert.strictEqual(
+      result.reason,
+      MULTIPLEXER_PROTOCOL_VERSION === 1
+        ? "same-version"
+        : "daemon-older-than-connector"
+    );
+    assert.strictEqual(result.daemonProtocolVersion, 1);
+    assert.deepStrictEqual(context.requests, [v1HealthRequest]);
+  });
+
+  it("[v1 compatibility gate] lets a v1 connector reuse a newer daemon", async function () {
+    const context = await startServer({
+      expectedRequest: v1HealthRequest,
+      protocolVersion: 2,
+    });
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.strictEqual(result.status, "usable");
+    assert.strictEqual(result.reason, "daemon-newer-compatible");
+    assert.deepStrictEqual(context.requests, [v1HealthRequest]);
+  });
+
+  it("requires replacement for an older daemon", async function () {
+    const context = await startServer({
+      protocolVersion: 0,
+    });
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.deepStrictEqual(result, {
+      status: "replace-required",
+      reason: "daemon-older-than-connector",
+      daemonProtocolVersion: 0,
+      connectorProtocolVersion: 1,
+    });
+  });
+
+  it("rejects replacement when an older daemon is in use", async function () {
+    const context = await startServer({
+      protocolVersion: 0,
+      isInUse: true,
+    });
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.deepStrictEqual(result, {
+      status: "unusable",
+      reason: "daemon-upgrade-blocked-by-active-connections",
+      daemonProtocolVersion: 0,
+      connectorProtocolVersion: 1,
+    });
+  });
+
+  it("reports an unreachable endpoint", async function () {
+    const context = createTempContext();
+    contexts.push(context);
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.strictEqual(result.status, "unusable");
+    assert.strictEqual(result.reason, "unreachable");
+    assert.ok(result.error instanceof Error);
+  });
+
+  it("reports a health probe timeout", async function () {
+    const context = createTempContext();
+    contexts.push(context);
+    const rawSockets = new Set();
+    const rawServer = net.createServer((socket) => {
+      rawSockets.add(socket);
+      socket.on("close", () => rawSockets.delete(socket));
+    });
+    trackServer(rawServer, rawSockets);
+    await listen(rawServer, context.endpoint);
+    const timeout = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+      healthCheckTimeout: 200,
+    }).probeHealth();
+    assert.deepStrictEqual(timeout, {
+      status: "unusable",
+      reason: "timeout",
+    });
+  });
+
+  it("reports an invalid health response", async function () {
+    const context = createTempContext();
+    contexts.push(context);
+    const invalidResponseServer = net.createServer((socket) => {
+      socket.once("data", () => socket.end(frame({ kind: "unexpected" })));
+    });
+    trackServer(invalidResponseServer);
+    await listen(invalidResponseServer, context.endpoint);
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.deepStrictEqual(result, {
+      status: "unusable",
+      reason: "invalid-response",
+    });
+  });
+
+  it("reports an invalid transport frame", async function () {
+    const context = createTempContext();
+    contexts.push(context);
+    const invalidFrameServer = net.createServer((socket) => {
+      socket.once("data", () => {
+        const bad = Buffer.alloc(FRAME_HEADER_SIZE + 1);
+        FRAME_PREFIX.copy(bad, 0);
+        bad.writeUInt32BE(2, FRAME_PREFIX.length);
+        bad[FRAME_HEADER_SIZE] = "{".charCodeAt(0);
+        socket.end(bad);
+      });
+    });
+    trackServer(invalidFrameServer);
+    await listen(invalidFrameServer, context.endpoint);
+    const result = await new MultiplexerDiscovery({
+      controlEndpoint: context.endpoint,
+      localProtocolVersion: 1,
+    }).probeHealth();
+    assert.strictEqual(result.status, "unusable");
+    assert.strictEqual(result.reason, "invalid-frame");
+    assert.ok(result.error instanceof Error);
+  });
+});

--- a/test/unit/multiplexer/protocol/validation.test.js
+++ b/test/unit/multiplexer/protocol/validation.test.js
@@ -12,6 +12,9 @@ const {
   isControlRpcRequest,
   isControlRpcResponse,
   isDeviceSnapshot,
+  isMultiplexerHealthRequest,
+  isMultiplexerHealthResponse,
+  isMultiplexerHandshakeErrorResponse,
   isNumberArray,
   isSnapshot,
   isStringArray,
@@ -288,6 +291,85 @@ describe("multiplexer protocol validation", function () {
     );
   });
 
+  it("validates Health DTOs without PID or versioned requests", function () {
+    assert.strictEqual(
+      isMultiplexerHealthRequest({
+        kind: "health",
+      }),
+      true
+    );
+    assert.strictEqual(
+      isMultiplexerHealthRequest({
+        kind: "health",
+        debugInfo: {
+          daemonVersion: "0.0.1",
+          processId: 123,
+          timestamp: 1000,
+        },
+        extraFutureField: "ignored",
+      }),
+      true
+    );
+    assert.strictEqual(
+      isMultiplexerHealthRequest({ kind: "health", debugInfo: "bad" }),
+      false
+    );
+    assert.strictEqual(
+      isMultiplexerHealthResponse({
+        kind: "health-response",
+        ok: true,
+        protocolVersion: 1,
+        isInUse: false,
+        debugInfo: {
+          daemonVersion: "0.0.1",
+          processId: 123,
+          timestamp: 1000,
+        },
+      }),
+      true
+    );
+    assert.strictEqual(
+      isMultiplexerHealthResponse({
+        kind: "health-response",
+        ok: true,
+        protocolVersion: 1,
+        isInUse: false,
+      }),
+      true
+    );
+    assert.strictEqual(
+      isMultiplexerHealthResponse({
+        kind: "health-response",
+        ok: false,
+        protocolVersion: 1,
+        isInUse: false,
+      }),
+      false
+    );
+    assert.strictEqual(
+      isMultiplexerHealthResponse({
+        kind: "health-response",
+        ok: true,
+        protocolVersion: 1,
+        isInUse: "false",
+      }),
+      false
+    );
+    assert.strictEqual(
+      isMultiplexerHandshakeErrorResponse({
+        kind: "handshake-error-response",
+        error: { code: "bad", message: "bad handshake" },
+      }),
+      true
+    );
+    assert.strictEqual(
+      isMultiplexerHandshakeErrorResponse({
+        kind: "handshake-error-response",
+      }),
+      false
+    );
+  });
+
   it("validates every control RPC request method branch", function () {
     const validCases = [
       [
@@ -330,10 +412,22 @@ describe("multiplexer protocol validation", function () {
           message: createCustomizedRequestMessage(),
         },
       ],
-      ["sendMessageWithoutReply", { target: "app", clientId: 1, message: null }],
-      ["sendMessageWithoutReply", { target: "app", clientId: 1, message: undefined }],
-      ["sendMessageWithoutReply", { target: "web", clientId: -1, message: "broadcast" }],
-      ["sendMessageWithoutReply", { target: "web", clientId: 2, message: "targeted" }],
+      [
+        "sendMessageWithoutReply",
+        { target: "app", clientId: 1, message: null },
+      ],
+      [
+        "sendMessageWithoutReply",
+        { target: "app", clientId: 1, message: undefined },
+      ],
+      [
+        "sendMessageWithoutReply",
+        { target: "web", clientId: -1, message: "broadcast" },
+      ],
+      [
+        "sendMessageWithoutReply",
+        { target: "web", clientId: 2, message: "targeted" },
+      ],
       [
         "sendMessageWithoutReply",
         { target: "web", clientId: -1, message: { event: "broadcast" } },

--- a/test/unit/multiplexer/utils/paths.test.js
+++ b/test/unit/multiplexer/utils/paths.test.js
@@ -1,0 +1,76 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("assert");
+const os = require("os");
+const path = require("path");
+
+const {
+  getDefaultMultiplexerRootDir,
+  getMultiplexerControlEndpoint,
+  getMultiplexerDataDir,
+} = require("../../../../debug_router_connector/dist/cjs/src/multiplexer/utils/paths");
+
+describe("multiplexer paths", function () {
+  it("uses the connector data directory as default root", function () {
+    assert.strictEqual(
+      getDefaultMultiplexerRootDir(),
+      path.join(os.homedir(), ".DebugRouterConnector")
+    );
+    assert.strictEqual(
+      getMultiplexerDataDir(),
+      path.join(os.homedir(), ".DebugRouterConnector", "multiplexer")
+    );
+  });
+
+  it("derives the Windows named pipe from the custom data directory", function () {
+    const endpoint = getMultiplexerControlEndpoint(
+      { dataDir: "C:\\Users\\tester\\mux" },
+      "win32"
+    );
+    assert.strictEqual(endpoint, "\\\\.\\pipe\\C:\\Users\\tester\\mux");
+    assert.strictEqual(
+      getMultiplexerControlEndpoint(
+        { dataDir: "D:\\another\\directory" },
+        "win32"
+      ),
+      "\\\\.\\pipe\\D:\\another\\directory"
+    );
+  });
+
+  it("uses control.sock directly even for a long Unix data directory", function () {
+    const dataDir = path.join(os.tmpdir(), "x".repeat(180));
+    assert.strictEqual(
+      getMultiplexerControlEndpoint({ dataDir }, "darwin"),
+      path.join(dataDir, "control.sock")
+    );
+  });
+
+  it("allows explicit data directory override and isolates endpoints", function () {
+    const firstDir = path.join(os.tmpdir(), "debug-router-mux-a");
+    const secondDir = path.join(os.tmpdir(), "debug-router-mux-b");
+    assert.strictEqual(getMultiplexerDataDir({ dataDir: firstDir }), firstDir);
+    assert.notStrictEqual(
+      getMultiplexerControlEndpoint({ dataDir: firstDir }, "darwin"),
+      getMultiplexerControlEndpoint({ dataDir: secondDir }, "darwin")
+    );
+  });
+
+  it("[v1 compatibility gate] keeps discovery endpoints stable", function () {
+    assert.strictEqual(
+      getMultiplexerControlEndpoint(
+        { dataDir: "/Users/test/.Debug Router/mux_1" },
+        "darwin"
+      ),
+      "/Users/test/.Debug Router/mux_1/control.sock"
+    );
+    assert.strictEqual(
+      getMultiplexerControlEndpoint(
+        { dataDir: "C:\\Users\\tester\\mux" },
+        "win32"
+      ),
+      "\\\\.\\pipe\\C:\\Users\\tester\\mux"
+    );
+  });
+});


### PR DESCRIPTION
Add fixed-endpoint health probing, protocol validation, discovery classification, and focused compatibility coverage for the staged multiplexer discovery migration.

doc: https://github.com/naitir64/debug-router/blob/multiplexer/agents/DebugRouter%20Multiplexer%20Technical%20Design.md

TEST: cd debug_router_connector && npx tsc -p tsconfig.json --noEmit && npm run test:multiplexer