### PR TITLE
[BugFix][Connector] Close stale USB and ADB connections

### DIFF
--- a/debug_router_connector/src/device/BaseDevice.ts
+++ b/debug_router_connector/src/device/BaseDevice.ts
@@ -55,7 +55,7 @@ export abstract class BaseDevice {
       os: this.info.os,
       title: this.info.title,
     });
-    this.clientController?.stopWatchClient();
+    this.clientController?.close();
     this.clientController = new ClientController(this.driver, this);
     this.clientController.startWatchClient();
   }

--- a/debug_router_connector/src/device/android/AndroidDevice.ts
+++ b/debug_router_connector/src/device/android/AndroidDevice.ts
@@ -17,6 +17,9 @@ import child_process, { ExecException } from "child_process";
 import { getDriverReportService } from "../../report/interface/DriverReportService";
 import { DeviceOS } from "../../utils/type";
 import { getAdbToolPath } from "../../utils/adb.validator";
+import ForwardCommand from "@devicefarmer/adbkit/dist/src/adb/command/host-serial/forward";
+import ListForwardsCommand from "@devicefarmer/adbkit/dist/src/adb/command/host-serial/listforwards";
+import { withAdbConnection } from "../../utils/adb.connection";
 
 export default class AndroidDevice extends BaseDevice {
   private adb: ADBClient;
@@ -86,9 +89,14 @@ export default class AndroidDevice extends BaseDevice {
           defaultLogger.debug("adb try hostport:" + hostport);
         } while (this.port.indexOf(hostport) != -1);
         try {
-          const result = await device.forward(
-            `tcp:${hostport}`,
-            `tcp:${remotePort}`,
+          const result = await withAdbConnection(
+            () => this.adb.connection(),
+            (connection) =>
+              new ForwardCommand(connection).execute(
+                this.serial,
+                `tcp:${hostport}`,
+                `tcp:${remotePort}`,
+              ),
           );
           if (result) {
             defaultLogger.debug(
@@ -128,7 +136,11 @@ export default class AndroidDevice extends BaseDevice {
   async adbForwardRemove(device: DeviceClient) {
     defaultLogger.debug("adbForwardRemove");
     return new Promise<void>(async (resolve, reject) => {
-      const forwards: Forward[] = await device.listForwards();
+      const forwards: Forward[] = await withAdbConnection(
+        () => this.adb.connection(),
+        (connection) =>
+          new ListForwardsCommand(connection).execute(this.serial),
+      );
       for (let i = 0; i < forwards.length; i++) {
         const local = forwards[i].local;
         const remote = forwards[i].remote;

--- a/debug_router_connector/src/usb/ClientController.ts
+++ b/debug_router_connector/src/usb/ClientController.ts
@@ -156,6 +156,8 @@ export class ClientController implements ClientEventsListener {
 
   close() {
     this.stopWatchClient();
+    this.sockets.forEach((adapter) => adapter.destroy());
+    this.sockets.clear();
     this.closeAllConnection();
   }
 }

--- a/debug_router_connector/src/utils/adb.connection.ts
+++ b/debug_router_connector/src/utils/adb.connection.ts
@@ -1,0 +1,32 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Socket } from "net";
+import AdbConnection from "@devicefarmer/adbkit/dist/src/adb/connection";
+
+export async function disposeAdbConnection(
+  connection: AdbConnection,
+): Promise<void> {
+  const socket = connection.getSocket() as Socket | undefined;
+  if (!socket || socket.destroyed) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    socket.once("close", resolve);
+    socket.destroy();
+  });
+}
+
+export async function withAdbConnection<T>(
+  connect: () => PromiseLike<AdbConnection>,
+  execute: (connection: AdbConnection) => T | PromiseLike<T>,
+): Promise<T> {
+  const connection = await connect();
+  try {
+    return await execute(connection);
+  } finally {
+    await disposeAdbConnection(connection);
+  }
+}

--- a/debug_router_connector/test/AdbConnection.test.js
+++ b/debug_router_connector/test/AdbConnection.test.js
@@ -1,0 +1,72 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const {
+  disposeAdbConnection,
+  withAdbConnection,
+} = require("../dist/cjs/src/utils/adb.connection");
+
+class FakeSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.destroyed = false;
+    this.destroyCalls = 0;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.destroyCalls += 1;
+    queueMicrotask(() => this.emit("close"));
+  }
+}
+
+function fakeConnection(socket) {
+  return {
+    getSocket() {
+      return socket;
+    },
+  };
+}
+
+describe("ADB connection disposal", () => {
+  it("waits for the socket to close after a successful command", async () => {
+    const socket = new FakeSocket();
+    const result = await withAdbConnection(
+      async () => fakeConnection(socket),
+      async () => "done",
+    );
+
+    assert.equal(result, "done");
+    assert.equal(socket.destroyCalls, 1);
+    assert.equal(socket.destroyed, true);
+  });
+
+  it("also closes the socket when the command fails", async () => {
+    const socket = new FakeSocket();
+
+    await assert.rejects(
+      withAdbConnection(
+        async () => fakeConnection(socket),
+        async () => {
+          throw new Error("command failed");
+        },
+      ),
+      /command failed/,
+    );
+
+    assert.equal(socket.destroyCalls, 1);
+  });
+
+  it("does not destroy an already destroyed socket again", async () => {
+    const socket = new FakeSocket();
+    socket.destroyed = true;
+
+    await disposeAdbConnection(fakeConnection(socket));
+
+    assert.equal(socket.destroyCalls, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- fully close the previous ClientController before replacing it and destroy all retained ClientAdapter sockets
- close transient adbkit connections used by Android forward and list-forward commands
- add regression tests for successful, failed, and already-closed ADB connection disposal

## Test Plan

- npm run build
- npx mocha test/AdbConnection.test.js (3 passing)
- npm run test:multiplexer (32 passing)