### PR TITLE
[Feature][iOS] Support config USB debug start port

### DIFF
--- a/DebugRouter.podspec
+++ b/DebugRouter.podspec
@@ -18,11 +18,15 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
   s.default_subspecs = 'Framework', 'Native', 'third_party'
+  ios_usb_start_port_definition = "DEBUGROUTER_ENABLE_IOS_USB_START_PORT=1 $(inherited)"
 
   s.subspec 'Framework' do |ss|
     ss.source_files = 'debug_router/ios/public/*.{h,m,mm}', 'debug_router/ios/public/base/*.{h,m,mm}', 'debug_router/ios/*.{h,m,mm}', 'debug_router/ios/net/*.{h,m,mm}', 'debug_router/ios/report/*.{h,m,mm}', 'debug_router/ios/base/*.{h,m,mm}', 'debug_router/ios/base/report/*.{h,m,mm}', 'debug_router/ios/base/service/*.{h,m,mm}'
     ss.frameworks = 'Network'
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/debug_router/ios/\"" }
+    ss.pod_target_xcconfig  = {
+      "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/debug_router/ios/\"",
+      "GCC_PREPROCESSOR_DEFINITIONS" => ios_usb_start_port_definition
+    }
     ss.dependency 'DebugRouter/Native'
     ss.public_header_files = 'debug_router/ios/public/DebugRouter.h', 'debug_router/ios/public/DebugRouterMessageHandler.h', 'debug_router/ios/public/DebugRouterCommon.h', 'debug_router/ios/public/DebugRouterMessageHandleResult.h', "debug_router/ios/public/DebugRouterEventSender.h", "debug_router/ios/public/DebugRouterGlobalHandler.h", "debug_router/ios/public/DebugRouterSlot.h", "debug_router/ios/public/base/DebugRouterReportServiceUtil.h", "debug_router/ios/public/base/DebugRouterToast.h", "debug_router/ios/public/DebugRouterSessionHandler.h", "debug_router/ios/public/base/DebugRouterDefines.h", "debug_router/ios/public/base/DebugRouterReportServiceProtocol.h", "debug_router/ios/public/base/DebugRouterService.h", "debug_router/ios/public/base/DebugRouterServiceProtocol.h", "debug_router/ios/public/LocalNetworkPermissionChecker.h"
   end
@@ -31,7 +35,10 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir  = "."
     ss.source_files = 'debug_router/native/**/*'
     ss.exclude_files = 'debug_router/native/android/**/*','debug_router/native/test/*','debug_router/native/socket/win/*', 'debug_router/native/harmony/**/*'
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" =>  "\"${PODS_TARGET_SRCROOT}\" \"${PODS_TARGET_SRCROOT}/third_party/jsoncpp/include\""}
+    ss.pod_target_xcconfig  = {
+      "HEADER_SEARCH_PATHS" =>  "\"${PODS_TARGET_SRCROOT}\" \"${PODS_TARGET_SRCROOT}/third_party/jsoncpp/include\"",
+      "GCC_PREPROCESSOR_DEFINITIONS" => ios_usb_start_port_definition
+    }
     ss.dependency 'DebugRouter/third_party'
     ss.private_header_files = 'debug_router/native/**/*.{h}'
   end

--- a/debug_router/ios/DebugRouter.mm
+++ b/debug_router/ios/DebugRouter.mm
@@ -195,6 +195,7 @@ class MessageHandlerDelegate : public debugrouter::core::DebugRouterMessageHandl
 - (void)handleDidBecomeActive:(NSNotification *)notification;
 - (void)handleEnterBackground:(NSNotification *)notification;
 @end
+
 @implementation DebugRouter {
   bool recordAppIdleTimerDisabledStatus;
   AppState appState_;
@@ -211,6 +212,12 @@ class MessageHandlerDelegate : public debugrouter::core::DebugRouterMessageHandl
   });
   return instance_;
 }
+
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
++ (BOOL)setUSBStartPort:(int)startPort {
+  return debugrouter::core::DebugRouterCore::GetInstance().SetUSBStartPort(startPort);
+}
+#endif
 
 - (instancetype)init {
   self = [super init];

--- a/debug_router/ios/public/DebugRouter.h
+++ b/debug_router/ios/public/DebugRouter.h
@@ -39,6 +39,9 @@ typedef enum : NSUInteger { ConnectionTypeWebSocket, ConnectionTypeUSB, Unknown 
     __attribute__((deprecated("will remove")));
 
 + (nonnull DebugRouter *)instance;
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
++ (BOOL)setUSBStartPort:(int)startPort;
+#endif
 
 - (void)disconnect;
 - (void)connect:(nonnull NSString *)url ToRoom:(nonnull NSString *)room;

--- a/debug_router/native/core/debug_router_core.cc
+++ b/debug_router/native/core/debug_router_core.cc
@@ -18,6 +18,9 @@
 #include "debug_router/native/net/websocket_client.h"
 #include "debug_router/native/processor/message_handler.h"
 #include "debug_router/native/processor/processor.h"
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+#include "debug_router/native/socket/socket_server_type.h"
+#endif
 #include "debug_router/native/thread/debug_router_executor.h"
 #include "json/value.h"
 
@@ -184,8 +187,13 @@ DebugRouterCore::DebugRouterCore()
   size_t transceiver_count = 0;
   message_transceivers_[transceiver_count++] =
       std::make_shared<net::WebSocketClient>();
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  socket_server_client_ = std::make_shared<net::SocketServerClient>();
+  message_transceivers_[transceiver_count++] = socket_server_client_;
+#else
   message_transceivers_[transceiver_count++] =
       std::make_shared<net::SocketServerClient>();
+#endif
 #endif
   for (size_t i = 0; i < kTransceiverCount; ++i) {
     message_transceivers_[i]->Init();
@@ -354,6 +362,39 @@ int32_t DebugRouterCore::Plug(const std::shared_ptr<core::NativeSlot> &slot) {
 int32_t DebugRouterCore::GetUSBPort() {
   return usb_port_.load(std::memory_order_relaxed);
 }
+
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+bool DebugRouterCore::SetUSBStartPort(int32_t start_port) {
+  if (start_port <= 0 ||
+      start_port > UINT16_MAX - socket_server::kTryPortCount + 1) {
+    LOGW("SetUSBStartPort ignored invalid start port: " << start_port);
+    return false;
+  }
+  LOGI("SetUSBStartPort: " << start_port);
+  if (!socket_server_client_) {
+    LOGW("SetUSBStartPort ignored because usb server is unavailable.");
+    return false;
+  }
+  if (server_running_.load(std::memory_order_relaxed)) {
+    thread::DebugRouterExecutor::GetInstance().Post([this, start_port]() {
+      const bool should_run = ShouldServerRun();
+      if (current_transceiver_ != nullptr &&
+          current_transceiver_->GetType() == ConnectionType::kUsb) {
+        current_transceiver_->Disconnect();
+      }
+      usb_port_.store(socket_server::kInvalidPort, std::memory_order_relaxed);
+      socket_server_client_->StopServer();
+      socket_server_client_->SetStartPort(start_port);
+      if (should_run) {
+        socket_server_client_->StartServer();
+      }
+    });
+  } else {
+    socket_server_client_->SetStartPort(start_port);
+  }
+  return true;
+}
+#endif
 
 void DebugRouterCore::Pull(int32_t session_id_) {
   LOGI("pull session: " << session_id_);

--- a/debug_router/native/core/debug_router_core.h
+++ b/debug_router/native/core/debug_router_core.h
@@ -31,6 +31,11 @@ class DebugRouterExecutor;
 namespace processor {
 class Processor;
 }
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+namespace net {
+class SocketServerClient;
+}
+#endif
 
 namespace core {
 
@@ -104,6 +109,10 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   int32_t Plug(const std::shared_ptr<core::NativeSlot> &slot);
 
   int32_t GetUSBPort();
+
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  bool SetUSBStartPort(int32_t start_port);
+#endif
 
   void Pull(int32_t session_id);
 
@@ -192,6 +201,9 @@ class DebugRouterCore : public MessageTransceiverDelegate {
   std::shared_ptr<MessageTransceiver> current_transceiver_;
   std::array<std::shared_ptr<MessageTransceiver>, kTransceiverCount>
       message_transceivers_;
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  std::shared_ptr<net::SocketServerClient> socket_server_client_;
+#endif
   int32_t max_session_id_;
   std::unique_ptr<report::DebugRouterNativeReport> report_;
   std::unique_ptr<debugrouter::processor::Processor> processor_;

--- a/debug_router/native/net/socket_server_client.cc
+++ b/debug_router/native/net/socket_server_client.cc
@@ -101,5 +101,11 @@ void SocketServerClient::StopServer() {
   }
 }
 
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+bool SocketServerClient::SetStartPort(int32_t start_port) {
+  return socket_server_ && socket_server_->SetStartPort(start_port);
+}
+#endif
+
 }  // namespace net
 }  // namespace debugrouter

--- a/debug_router/native/net/socket_server_client.h
+++ b/debug_router/native/net/socket_server_client.h
@@ -23,6 +23,9 @@ class SocketServerClient : public core::MessageTransceiver {
 
   void StartServer() override;
   void StopServer() override;
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  bool SetStartPort(int32_t start_port);
+#endif
 
  private:
   std::shared_ptr<debugrouter::socket_server::SocketServer> socket_server_;

--- a/debug_router/native/socket/posix/socket_server_posix.cc
+++ b/debug_router/native/socket/posix/socket_server_posix.cc
@@ -42,13 +42,18 @@ int32_t SocketServerPosix::InitSocket() {
   }
 
   bool flag = false;
-  PORT_TYPE port = kStartPort;
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  const PORT_TYPE start_port = GetStartPort();
+#else
+  const PORT_TYPE start_port = kStartPort;
+#endif
+  int32_t port = start_port;
   do {
     struct sockaddr_in addr;
     bzero((char *)&addr, sizeof(addr));
 
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
+    addr.sin_port = htons(static_cast<PORT_TYPE>(port));
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
     if (bind(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
@@ -56,7 +61,7 @@ int32_t SocketServerPosix::InitSocket() {
       break;
     }
     port = port + 1;
-  } while ((port < kStartPort + kTryPortCount) &&
+  } while ((port < start_port + kTryPortCount) &&
            (GetErrorMessage() == EADDRINUSE));
 
   if (!flag) {

--- a/debug_router/native/socket/socket_server_api.cc
+++ b/debug_router/native/socket/socket_server_api.cc
@@ -50,6 +50,21 @@ bool SocketServer::Send(const std::string &message) {
   return client->Send(message);
 }
 
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+bool SocketServer::SetStartPort(int32_t start_port) {
+  if (start_port <= 0 || start_port > UINT16_MAX - kTryPortCount + 1) {
+    return false;
+  }
+  start_port_.store(static_cast<PORT_TYPE>(start_port),
+                    std::memory_order_relaxed);
+  return true;
+}
+
+PORT_TYPE SocketServer::GetStartPort() {
+  return start_port_.load(std::memory_order_relaxed);
+}
+#endif
+
 void SocketServer::HandleOnOpenStatus(std::shared_ptr<UsbClient> client,
                                       int32_t code, const std::string &reason) {
   thread::DebugRouterExecutor::GetInstance().Post([=]() {
@@ -213,7 +228,13 @@ void SocketServer::NotifyInit(int32_t code, const std::string &info) {
 void SocketServer::setEnableServer(bool enable) {
   LOGI("SocketServer::setEnableServer:" << enable);
   // notify only when transition from false to true
-  if (!is_running_.exchange(enable, std::memory_order_relaxed) && enable) {
+  bool should_notify = false;
+  {
+    std::lock_guard<std::mutex> lock(running_mutex_);
+    should_notify =
+        !is_running_.exchange(enable, std::memory_order_relaxed) && enable;
+  }
+  if (should_notify) {
     running_condition_.notify_one();
   }
 }
@@ -236,6 +257,10 @@ void SocketServer::StopServer() {
 
   Close();
   {
+    std::unique_lock<std::mutex> lock(serving_mutex_);
+    serving_condition_.wait(lock, [this]() { return !is_serving_; });
+  }
+  {
     std::lock_guard<std::mutex> lock(client_lock_);
     current_client = usb_client_;
     pending_client = temp_usb_client_;
@@ -254,14 +279,21 @@ void SocketServer::ThreadFunc(std::shared_ptr<SocketServer> socket_server) {
   int count = 0;
   while (true) {
     {
-      std::unique_lock lock(socket_server->running_mutex_);
-      socket_server->running_condition_.wait(lock, [=]() {
+      std::unique_lock running_lock(socket_server->running_mutex_);
+      socket_server->running_condition_.wait(running_lock, [=]() {
         return socket_server->is_running_.load(std::memory_order_relaxed) ==
                true;
       });
+      std::lock_guard<std::mutex> serving_lock(socket_server->serving_mutex_);
+      socket_server->is_serving_ = true;
     }
     LOGI("Init start:" << count);
     socket_server->Start();
+    {
+      std::lock_guard<std::mutex> lock(socket_server->serving_mutex_);
+      socket_server->is_serving_ = false;
+    }
+    socket_server->serving_condition_.notify_all();
     count++;
   }
 }

--- a/debug_router/native/socket/socket_server_api.h
+++ b/debug_router/native/socket/socket_server_api.h
@@ -37,6 +37,9 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   void Init();
   bool Send(const std::string &message);
   void Disconnect();
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  bool SetStartPort(int32_t start_port);
+#endif
 
   void HandleOnOpenStatus(std::shared_ptr<UsbClient> client, int32_t code,
                           const std::string &reason);
@@ -64,6 +67,9 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   virtual void CloseSocket(int socket_fd) = 0;
   void Close();
   void NotifyInit(int32_t code, const std::string &info);
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  PORT_TYPE GetStartPort();
+#endif
 
   void setEnableServer(bool enable);
 
@@ -80,9 +86,15 @@ class SocketServer : public std::enable_shared_from_this<SocketServer> {
   std::atomic<SocketType> socket_fd_{kInvalidSocket};
 
  private:
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+  std::atomic<PORT_TYPE> start_port_{kStartPort};
+#endif
   std::atomic<bool> is_running_{false};
   std::condition_variable running_condition_;
   std::mutex running_mutex_;
+  bool is_serving_{false};
+  std::condition_variable serving_condition_;
+  std::mutex serving_mutex_;
 };
 
 // ClientListener

--- a/debug_router/native/test/socket_util_unittest.cc
+++ b/debug_router/native/test/socket_util_unittest.cc
@@ -56,6 +56,36 @@ std::set<int32_t> ScanOccupiedDebugRouterPorts() {
   return ports;
 }
 
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+bool CanBindPort(int32_t port) {
+  const int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socket_fd < 0) {
+    return false;
+  }
+  int on = 1;
+  setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(port));
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+  const bool can_bind =
+      bind(socket_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+  close(socket_fd);
+  return can_bind;
+}
+
+int32_t FindAvailablePort(int32_t start_port, int32_t end_port) {
+  for (int32_t port = start_port; port <= end_port; ++port) {
+    if (CanBindPort(port)) {
+      return port;
+    }
+  }
+  return debugrouter::socket_server::kInvalidPort;
+}
+#endif
+
 template <class Predicate>
 bool WaitUntil(Predicate predicate, int timeout_ms = 2000) {
   const auto deadline =
@@ -171,6 +201,46 @@ TEST(SocketUtilTestSuite, TestCheckHeader) {
 }
 
 #ifndef _WIN32
+#if defined(DEBUGROUTER_ENABLE_IOS_USB_START_PORT)
+TEST(SocketUtilTestSuite, SettingUsbStartPortRestartsRunningDebugChannel) {
+  auto& core = debugrouter::core::DebugRouterCore::GetInstance();
+  core.DisableDebugChannel();
+
+  const int32_t first_port = FindAvailablePort(19101, 19200);
+  ASSERT_NE(first_port, debugrouter::socket_server::kInvalidPort);
+  ASSERT_TRUE(core.SetUSBStartPort(first_port));
+  core.EnableDebugChannel();
+
+  int first_client_socket = -1;
+  ASSERT_TRUE(WaitUntil([&]() {
+    if (core.GetUSBPort() != first_port) {
+      return false;
+    }
+    first_client_socket = ConnectToLocalUsbPort(first_port);
+    return first_client_socket >= 0;
+  }));
+  close(first_client_socket);
+
+  const int32_t second_port = FindAvailablePort(first_port + 1, 19250);
+  ASSERT_NE(second_port, debugrouter::socket_server::kInvalidPort);
+  ASSERT_TRUE(core.SetUSBStartPort(second_port));
+
+  int second_client_socket = -1;
+  ASSERT_TRUE(WaitUntil([&]() {
+    if (core.GetUSBPort() != second_port) {
+      return false;
+    }
+    second_client_socket = ConnectToLocalUsbPort(second_port);
+    return second_client_socket >= 0;
+  }));
+  EXPECT_EQ(core.GetUSBPort(), second_port);
+
+  close(second_client_socket);
+  core.DisableDebugChannel();
+  ASSERT_TRUE(core.SetUSBStartPort(debugrouter::socket_server::kStartPort));
+}
+#endif
+
 TEST(SocketUtilTestSuite, SendNoSigPipeFailsWithoutTerminatingOnClosedPeer) {
   int sockets[2] = {-1, -1};
   ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);


### PR DESCRIPTION
Add an iOS-facing API to set the USB debug server start port. Restart the USB server when the debug channel is already running so the new port takes effect.